### PR TITLE
Lane County 2004 primary, 2002 general

### DIFF
--- a/2002/20021105__or__general__lane__precinct.csv
+++ b/2002/20021105__or__general__lane__precinct.csv
@@ -1,0 +1,1142 @@
+county,precinct,office,district,party,candidate,votes
+Lane,100601 FLORENCE 1,U.S. Senate,,CONST,Lon Mabon,30
+Lane,100601 FLORENCE 1,U.S. Senate,,DEM,Bill Bradbury,657
+Lane,100601 FLORENCE 1,U.S. Senate,,REP,Gordon H. Smith,834
+Lane,100601 FLORENCE 1,U.S. Senate,,LIB,Dan Fitzgerald,45
+Lane,100116 RIVER ROAD,U.S. Senate,,CONST,Lon Mabon,66
+Lane,100116 RIVER ROAD,U.S. Senate,,DEM,Bill Bradbury,1850
+Lane,100116 RIVER ROAD,U.S. Senate,,REP,Gordon H. Smith,1298
+Lane,100116 RIVER ROAD,U.S. Senate,,LIB,Dan Fitzgerald,98
+Lane,100112 PLEASANT HILL 2,U.S. Senate,,CONST,Lon Mabon,8
+Lane,100112 PLEASANT HILL 2,U.S. Senate,,DEM,Bill Bradbury,194
+Lane,100112 PLEASANT HILL 2,U.S. Senate,,REP,Gordon H. Smith,174
+Lane,100112 PLEASANT HILL 2,U.S. Senate,,LIB,Dan Fitzgerald,8
+Lane,101215 EUGENE 215,U.S. Senate,,CONST,Lon Mabon,25
+Lane,101215 EUGENE 215,U.S. Senate,,DEM,Bill Bradbury,1874
+Lane,101215 EUGENE 215,U.S. Senate,,REP,Gordon H. Smith,872
+Lane,101215 EUGENE 215,U.S. Senate,,LIB,Dan Fitzgerald,50
+Lane,100105 MARCOLA,U.S. Senate,,CONST,Lon Mabon,24
+Lane,100105 MARCOLA,U.S. Senate,,DEM,Bill Bradbury,319
+Lane,100105 MARCOLA,U.S. Senate,,REP,Gordon H. Smith,378
+Lane,100105 MARCOLA,U.S. Senate,,LIB,Dan Fitzgerald,23
+Lane,100130 SIUSLAW,U.S. Senate,,CONST,Lon Mabon,26
+Lane,100130 SIUSLAW,U.S. Senate,,DEM,Bill Bradbury,617
+Lane,100130 SIUSLAW,U.S. Senate,,REP,Gordon H. Smith,756
+Lane,100130 SIUSLAW,U.S. Senate,,LIB,Dan Fitzgerald,34
+Lane,101439 EUGENE 439,U.S. Senate,,CONST,Lon Mabon,27
+Lane,101439 EUGENE 439,U.S. Senate,,DEM,Bill Bradbury,975
+Lane,101439 EUGENE 439,U.S. Senate,,REP,Gordon H. Smith,1418
+Lane,101439 EUGENE 439,U.S. Senate,,LIB,Dan Fitzgerald,34
+Lane,100087 GLENADA,U.S. Senate,,CONST,Lon Mabon,17
+Lane,100087 GLENADA,U.S. Senate,,DEM,Bill Bradbury,373
+Lane,100087 GLENADA,U.S. Senate,,REP,Gordon H. Smith,423
+Lane,100087 GLENADA,U.S. Senate,,LIB,Dan Fitzgerald,22
+Lane,100128 SANTA CLARA 8,U.S. Senate,,CONST,Lon Mabon,43
+Lane,100128 SANTA CLARA 8,U.S. Senate,,DEM,Bill Bradbury,703
+Lane,100128 SANTA CLARA 8,U.S. Senate,,REP,Gordon H. Smith,882
+Lane,100128 SANTA CLARA 8,U.S. Senate,,LIB,Dan Fitzgerald,37
+Lane,101223 EUGENE 223,U.S. Senate,,CONST,Lon Mabon,24
+Lane,101223 EUGENE 223,U.S. Senate,,DEM,Bill Bradbury,1640
+Lane,101223 EUGENE 223,U.S. Senate,,REP,Gordon H. Smith,702
+Lane,101223 EUGENE 223,U.S. Senate,,LIB,Dan Fitzgerald,44
+Lane,101505 EUGENE 505,U.S. Senate,,CONST,Lon Mabon,8
+Lane,101505 EUGENE 505,U.S. Senate,,DEM,Bill Bradbury,111
+Lane,101505 EUGENE 505,U.S. Senate,,REP,Gordon H. Smith,204
+Lane,101505 EUGENE 505,U.S. Senate,,LIB,Dan Fitzgerald,3
+Lane,100103 MAPLETON,U.S. Senate,,CONST,Lon Mabon,11
+Lane,100103 MAPLETON,U.S. Senate,,DEM,Bill Bradbury,297
+Lane,100103 MAPLETON,U.S. Senate,,REP,Gordon H. Smith,288
+Lane,100103 MAPLETON,U.S. Senate,,LIB,Dan Fitzgerald,18
+Lane,100007 BLUE RIVER,U.S. Senate,,CONST,Lon Mabon,19
+Lane,100007 BLUE RIVER,U.S. Senate,,DEM,Bill Bradbury,467
+Lane,100007 BLUE RIVER,U.S. Senate,,REP,Gordon H. Smith,506
+Lane,100007 BLUE RIVER,U.S. Senate,,LIB,Dan Fitzgerald,21
+Lane,100001 ALVADORE,U.S. Senate,,CONST,Lon Mabon,18
+Lane,100001 ALVADORE,U.S. Senate,,DEM,Bill Bradbury,384
+Lane,100001 ALVADORE,U.S. Senate,,REP,Gordon H. Smith,699
+Lane,100001 ALVADORE,U.S. Senate,,LIB,Dan Fitzgerald,29
+Lane,100012 CHESHIRE,U.S. Senate,,CONST,Lon Mabon,32
+Lane,100012 CHESHIRE,U.S. Senate,,DEM,Bill Bradbury,658
+Lane,100012 CHESHIRE,U.S. Senate,,REP,Gordon H. Smith,1491
+Lane,100012 CHESHIRE,U.S. Senate,,LIB,Dan Fitzgerald,36
+Lane,101435 EUGENE 435,U.S. Senate,,CONST,Lon Mabon,21
+Lane,101435 EUGENE 435,U.S. Senate,,DEM,Bill Bradbury,874
+Lane,101435 EUGENE 435,U.S. Senate,,REP,Gordon H. Smith,1162
+Lane,101435 EUGENE 435,U.S. Senate,,LIB,Dan Fitzgerald,49
+Lane,101317 EUGENE 317,U.S. Senate,,CONST,Lon Mabon,10
+Lane,101317 EUGENE 317,U.S. Senate,,DEM,Bill Bradbury,1848
+Lane,101317 EUGENE 317,U.S. Senate,,REP,Gordon H. Smith,433
+Lane,101317 EUGENE 317,U.S. Senate,,LIB,Dan Fitzgerald,37
+Lane,100107 MOSBY,U.S. Senate,,CONST,Lon Mabon,50
+Lane,100107 MOSBY,U.S. Senate,,DEM,Bill Bradbury,811
+Lane,100107 MOSBY,U.S. Senate,,REP,Gordon H. Smith,1291
+Lane,100107 MOSBY,U.S. Senate,,LIB,Dan Fitzgerald,55
+Lane,101101 EUGENE 101,U.S. Senate,,CONST,Lon Mabon,45
+Lane,101101 EUGENE 101,U.S. Senate,,DEM,Bill Bradbury,1893
+Lane,101101 EUGENE 101,U.S. Senate,,REP,Gordon H. Smith,923
+Lane,101101 EUGENE 101,U.S. Senate,,LIB,Dan Fitzgerald,58
+Lane,100084 FOX HOLLOW,U.S. Senate,,CONST,Lon Mabon,12
+Lane,100084 FOX HOLLOW,U.S. Senate,,DEM,Bill Bradbury,551
+Lane,100084 FOX HOLLOW,U.S. Senate,,REP,Gordon H. Smith,407
+Lane,100084 FOX HOLLOW,U.S. Senate,,LIB,Dan Fitzgerald,21
+Lane,100008 COAST FORK,U.S. Senate,,CONST,Lon Mabon,29
+Lane,100008 COAST FORK,U.S. Senate,,DEM,Bill Bradbury,417
+Lane,100008 COAST FORK,U.S. Senate,,REP,Gordon H. Smith,765
+Lane,100008 COAST FORK,U.S. Senate,,LIB,Dan Fitzgerald,37
+Lane,100111 PLEASANT HILL 1,U.S. Senate,,CONST,Lon Mabon,42
+Lane,100111 PLEASANT HILL 1,U.S. Senate,,DEM,Bill Bradbury,865
+Lane,100111 PLEASANT HILL 1,U.S. Senate,,REP,Gordon H. Smith,1415
+Lane,100111 PLEASANT HILL 1,U.S. Senate,,LIB,Dan Fitzgerald,60
+Lane,101117 EUGENE 117,U.S. Senate,,CONST,Lon Mabon,7
+Lane,101117 EUGENE 117,U.S. Senate,,DEM,Bill Bradbury,581
+Lane,101117 EUGENE 117,U.S. Senate,,REP,Gordon H. Smith,76
+Lane,101117 EUGENE 117,U.S. Senate,,LIB,Dan Fitzgerald,31
+Lane,101433 EUGENE 433,U.S. Senate,,CONST,Lon Mabon,19
+Lane,101433 EUGENE 433,U.S. Senate,,DEM,Bill Bradbury,787
+Lane,101433 EUGENE 433,U.S. Senate,,REP,Gordon H. Smith,751
+Lane,101433 EUGENE 433,U.S. Senate,,LIB,Dan Fitzgerald,35
+Lane,100100 LORANE,U.S. Senate,,CONST,Lon Mabon,19
+Lane,100100 LORANE,U.S. Senate,,DEM,Bill Bradbury,403
+Lane,100100 LORANE,U.S. Senate,,REP,Gordon H. Smith,518
+Lane,100100 LORANE,U.S. Senate,,LIB,Dan Fitzgerald,31
+Lane,100400 CRESWELL,U.S. Senate,,CONST,Lon Mabon,30
+Lane,100400 CRESWELL,U.S. Senate,,DEM,Bill Bradbury,307
+Lane,100400 CRESWELL,U.S. Senate,,REP,Gordon H. Smith,665
+Lane,100400 CRESWELL,U.S. Senate,,LIB,Dan Fitzgerald,21
+Lane,100155 MCKENZIE,U.S. Senate,,CONST,Lon Mabon,56
+Lane,100155 MCKENZIE,U.S. Senate,,DEM,Bill Bradbury,747
+Lane,100155 MCKENZIE,U.S. Senate,,REP,Gordon H. Smith,1372
+Lane,100155 MCKENZIE,U.S. Senate,,LIB,Dan Fitzgerald,51
+Lane,100900 VENETA,U.S. Senate,,CONST,Lon Mabon,24
+Lane,100900 VENETA,U.S. Senate,,DEM,Bill Bradbury,287
+Lane,100900 VENETA,U.S. Senate,,REP,Gordon H. Smith,470
+Lane,100900 VENETA,U.S. Senate,,LIB,Dan Fitzgerald,32
+Lane,100800 OAKRIDGE,U.S. Senate,,CONST,Lon Mabon,31
+Lane,100800 OAKRIDGE,U.S. Senate,,DEM,Bill Bradbury,400
+Lane,100800 OAKRIDGE,U.S. Senate,,REP,Gordon H. Smith,524
+Lane,100800 OAKRIDGE,U.S. Senate,,LIB,Dan Fitzgerald,28
+Lane,100124 SANTA CLARA 4,U.S. Senate,,CONST,Lon Mabon,52
+Lane,100124 SANTA CLARA 4,U.S. Senate,,DEM,Bill Bradbury,1109
+Lane,100124 SANTA CLARA 4,U.S. Senate,,REP,Gordon H. Smith,1607
+Lane,100124 SANTA CLARA 4,U.S. Senate,,LIB,Dan Fitzgerald,57
+Lane,100091 GROVEDALE,U.S. Senate,,CONST,Lon Mabon,15
+Lane,100091 GROVEDALE,U.S. Senate,,DEM,Bill Bradbury,331
+Lane,100091 GROVEDALE,U.S. Senate,,REP,Gordon H. Smith,381
+Lane,100091 GROVEDALE,U.S. Senate,,LIB,Dan Fitzgerald,13
+Lane,100004 BAILEY,U.S. Senate,,CONST,Lon Mabon,15
+Lane,100004 BAILEY,U.S. Senate,,DEM,Bill Bradbury,489
+Lane,100004 BAILEY,U.S. Senate,,REP,Gordon H. Smith,616
+Lane,100004 BAILEY,U.S. Senate,,LIB,Dan Fitzgerald,17
+Lane,100090 GOSHEN,U.S. Senate,,CONST,Lon Mabon,25
+Lane,100090 GOSHEN,U.S. Senate,,DEM,Bill Bradbury,662
+Lane,100090 GOSHEN,U.S. Senate,,REP,Gordon H. Smith,752
+Lane,100090 GOSHEN,U.S. Senate,,LIB,Dan Fitzgerald,55
+Lane,100003 ARMITAGE,U.S. Senate,,CONST,Lon Mabon,15
+Lane,100003 ARMITAGE,U.S. Senate,,DEM,Bill Bradbury,281
+Lane,100003 ARMITAGE,U.S. Senate,,REP,Gordon H. Smith,439
+Lane,100003 ARMITAGE,U.S. Senate,,LIB,Dan Fitzgerald,18
+Lane,100200 COBURG,U.S. Senate,,CONST,Lon Mabon,3
+Lane,100200 COBURG,U.S. Senate,,DEM,Bill Bradbury,169
+Lane,100200 COBURG,U.S. Senate,,REP,Gordon H. Smith,212
+Lane,100200 COBURG,U.S. Senate,,LIB,Dan Fitzgerald,9
+Lane,101237 EUGENE 237,U.S. Senate,,CONST,Lon Mabon,16
+Lane,101237 EUGENE 237,U.S. Senate,,DEM,Bill Bradbury,1409
+Lane,101237 EUGENE 237,U.S. Senate,,REP,Gordon H. Smith,798
+Lane,101237 EUGENE 237,U.S. Senate,,LIB,Dan Fitzgerald,25
+Lane,101315 EUGENE 315,U.S. Senate,,CONST,Lon Mabon,13
+Lane,101315 EUGENE 315,U.S. Senate,,DEM,Bill Bradbury,1727
+Lane,101315 EUGENE 315,U.S. Senate,,REP,Gordon H. Smith,372
+Lane,101315 EUGENE 315,U.S. Senate,,LIB,Dan Fitzgerald,36
+Lane,100095 GATEWAY,U.S. Senate,,CONST,Lon Mabon,13
+Lane,100095 GATEWAY,U.S. Senate,,DEM,Bill Bradbury,305
+Lane,100095 GATEWAY,U.S. Senate,,REP,Gordon H. Smith,375
+Lane,100095 GATEWAY,U.S. Senate,,LIB,Dan Fitzgerald,34
+Lane,100080 ELMIRA,U.S. Senate,,CONST,Lon Mabon,37
+Lane,100080 ELMIRA,U.S. Senate,,DEM,Bill Bradbury,627
+Lane,100080 ELMIRA,U.S. Senate,,REP,Gordon H. Smith,892
+Lane,100080 ELMIRA,U.S. Senate,,LIB,Dan Fitzgerald,64
+Lane,100152 WALTERVILLE,U.S. Senate,,CONST,Lon Mabon,27
+Lane,100152 WALTERVILLE,U.S. Senate,,DEM,Bill Bradbury,548
+Lane,100152 WALTERVILLE,U.S. Senate,,REP,Gordon H. Smith,1011
+Lane,100152 WALTERVILLE,U.S. Senate,,LIB,Dan Fitzgerald,24
+Lane,101105 EUGENE 105,U.S. Senate,,CONST,Lon Mabon,5
+Lane,101105 EUGENE 105,U.S. Senate,,DEM,Bill Bradbury,388
+Lane,101105 EUGENE 105,U.S. Senate,,REP,Gordon H. Smith,110
+Lane,101105 EUGENE 105,U.S. Senate,,LIB,Dan Fitzgerald,15
+Lane,100602 FLORENCE 2,U.S. Senate,,CONST,Lon Mabon,39
+Lane,100602 FLORENCE 2,U.S. Senate,,DEM,Bill Bradbury,748
+Lane,100602 FLORENCE 2,U.S. Senate,,REP,Gordon H. Smith,998
+Lane,100602 FLORENCE 2,U.S. Senate,,LIB,Dan Fitzgerald,31
+Lane,100300 COTTAGE GROVE,U.S. Senate,,CONST,Lon Mabon,63
+Lane,100300 COTTAGE GROVE,U.S. Senate,,DEM,Bill Bradbury,944
+Lane,100300 COTTAGE GROVE,U.S. Senate,,REP,Gordon H. Smith,1540
+Lane,100300 COTTAGE GROVE,U.S. Senate,,LIB,Dan Fitzgerald,79
+Lane,100121 SANTA CLARA 1,U.S. Senate,,CONST,Lon Mabon,17
+Lane,100121 SANTA CLARA 1,U.S. Senate,,DEM,Bill Bradbury,338
+Lane,100121 SANTA CLARA 1,U.S. Senate,,REP,Gordon H. Smith,529
+Lane,100121 SANTA CLARA 1,U.S. Senate,,LIB,Dan Fitzgerald,30
+Lane,101313 EUGENE 313,U.S. Senate,,CONST,Lon Mabon,21
+Lane,101313 EUGENE 313,U.S. Senate,,DEM,Bill Bradbury,892
+Lane,101313 EUGENE 313,U.S. Senate,,REP,Gordon H. Smith,213
+Lane,101313 EUGENE 313,U.S. Senate,,LIB,Dan Fitzgerald,60
+Lane,101107 EUGENE 107,U.S. Senate,,CONST,Lon Mabon,4
+Lane,101107 EUGENE 107,U.S. Senate,,DEM,Bill Bradbury,416
+Lane,101107 EUGENE 107,U.S. Senate,,REP,Gordon H. Smith,63
+Lane,101107 EUGENE 107,U.S. Senate,,LIB,Dan Fitzgerald,25
+Lane,101431 EUGENE 431,U.S. Senate,,CONST,Lon Mabon,4
+Lane,101431 EUGENE 431,U.S. Senate,,DEM,Bill Bradbury,393
+Lane,101431 EUGENE 431,U.S. Senate,,REP,Gordon H. Smith,300
+Lane,101431 EUGENE 431,U.S. Senate,,LIB,Dan Fitzgerald,15
+Lane,100119 SALMON CREEK,U.S. Senate,,CONST,Lon Mabon,7
+Lane,100119 SALMON CREEK,U.S. Senate,,DEM,Bill Bradbury,194
+Lane,100119 SALMON CREEK,U.S. Senate,,REP,Gordon H. Smith,305
+Lane,100119 SALMON CREEK,U.S. Senate,,LIB,Dan Fitzgerald,16
+Lane,100009 CAMAS,U.S. Senate,,CONST,Lon Mabon,3
+Lane,100009 CAMAS,U.S. Senate,,DEM,Bill Bradbury,124
+Lane,100009 CAMAS,U.S. Senate,,REP,Gordon H. Smith,181
+Lane,100009 CAMAS,U.S. Senate,,LIB,Dan Fitzgerald,9
+Lane,100086 GARDEN WAY,U.S. Senate,,CONST,Lon Mabon,8
+Lane,100086 GARDEN WAY,U.S. Senate,,DEM,Bill Bradbury,144
+Lane,100086 GARDEN WAY,U.S. Senate,,REP,Gordon H. Smith,88
+Lane,100086 GARDEN WAY,U.S. Senate,,LIB,Dan Fitzgerald,20
+Lane,100082 FERNRIDGE,U.S. Senate,,CONST,Lon Mabon,33
+Lane,100082 FERNRIDGE,U.S. Senate,,DEM,Bill Bradbury,501
+Lane,100082 FERNRIDGE,U.S. Senate,,REP,Gordon H. Smith,790
+Lane,100082 FERNRIDGE,U.S. Senate,,LIB,Dan Fitzgerald,42
+Lane,101235 EUGENE 235,U.S. Senate,,CONST,Lon Mabon,18
+Lane,101235 EUGENE 235,U.S. Senate,,DEM,Bill Bradbury,1453
+Lane,101235 EUGENE 235,U.S. Senate,,REP,Gordon H. Smith,385
+Lane,101235 EUGENE 235,U.S. Senate,,LIB,Dan Fitzgerald,38
+Lane,100005 BLACHLY,U.S. Senate,,CONST,Lon Mabon,19
+Lane,100005 BLACHLY,U.S. Senate,,DEM,Bill Bradbury,383
+Lane,100005 BLACHLY,U.S. Senate,,REP,Gordon H. Smith,435
+Lane,100005 BLACHLY,U.S. Senate,,LIB,Dan Fitzgerald,35
+Lane,100102 LOWELL,U.S. Senate,,CONST,Lon Mabon,24
+Lane,100102 LOWELL,U.S. Senate,,DEM,Bill Bradbury,355
+Lane,100102 LOWELL,U.S. Senate,,REP,Gordon H. Smith,433
+Lane,100102 LOWELL,U.S. Senate,,LIB,Dan Fitzgerald,27
+Lane,101103 EUGENE 103,U.S. Senate,,CONST,Lon Mabon,22
+Lane,101103 EUGENE 103,U.S. Senate,,DEM,Bill Bradbury,2352
+Lane,101103 EUGENE 103,U.S. Senate,,REP,Gordon H. Smith,461
+Lane,101103 EUGENE 103,U.S. Senate,,LIB,Dan Fitzgerald,53
+Lane,100097 LATHAM,U.S. Senate,,CONST,Lon Mabon,37
+Lane,100097 LATHAM,U.S. Senate,,DEM,Bill Bradbury,445
+Lane,100097 LATHAM,U.S. Senate,,REP,Gordon H. Smith,818
+Lane,100097 LATHAM,U.S. Senate,,LIB,Dan Fitzgerald,41
+Lane,100700 JUNCTION CITY,U.S. Senate,,CONST,Lon Mabon,41
+Lane,100700 JUNCTION CITY,U.S. Senate,,DEM,Bill Bradbury,421
+Lane,100700 JUNCTION CITY,U.S. Senate,,REP,Gordon H. Smith,914
+Lane,100700 JUNCTION CITY,U.S. Senate,,LIB,Dan Fitzgerald,27
+Lane,101109 EUGENE 109,U.S. Senate,,CONST,Lon Mabon,4
+Lane,101109 EUGENE 109,U.S. Senate,,DEM,Bill Bradbury,41
+Lane,101109 EUGENE 109,U.S. Senate,,REP,Gordon H. Smith,18
+Lane,101109 EUGENE 109,U.S. Senate,,LIB,Dan Fitzgerald,1
+Lane,100153 WILKINS,U.S. Senate,,CONST,Lon Mabon,14
+Lane,100153 WILKINS,U.S. Senate,,DEM,Bill Bradbury,421
+Lane,100153 WILKINS,U.S. Senate,,REP,Gordon H. Smith,691
+Lane,100153 WILKINS,U.S. Senate,,LIB,Dan Fitzgerald,22
+Lane,100500 DUNES CITY,U.S. Senate,,CONST,Lon Mabon,14
+Lane,100500 DUNES CITY,U.S. Senate,,DEM,Bill Bradbury,266
+Lane,100500 DUNES CITY,U.S. Senate,,REP,Gordon H. Smith,380
+Lane,100500 DUNES CITY,U.S. Senate,,LIB,Dan Fitzgerald,14
+Lane,101511 EUGENE 511,U.S. Senate,,CONST,Lon Mabon,33
+Lane,101511 EUGENE 511,U.S. Senate,,DEM,Bill Bradbury,1345
+Lane,101511 EUGENE 511,U.S. Senate,,REP,Gordon H. Smith,1721
+Lane,101511 EUGENE 511,U.S. Senate,,LIB,Dan Fitzgerald,57
+Lane,102304 SPRINGFIELD 304,U.S. Senate,,CONST,Lon Mabon,97
+Lane,102304 SPRINGFIELD 304,U.S. Senate,,DEM,Bill Bradbury,1153
+Lane,102304 SPRINGFIELD 304,U.S. Senate,,REP,Gordon H. Smith,1239
+Lane,102304 SPRINGFIELD 304,U.S. Senate,,LIB,Dan Fitzgerald,101
+Lane,101717 EUGENE 717,U.S. Senate,,CONST,Lon Mabon,1
+Lane,101717 EUGENE 717,U.S. Senate,,DEM,Bill Bradbury,112
+Lane,101717 EUGENE 717,U.S. Senate,,REP,Gordon H. Smith,46
+Lane,101717 EUGENE 717,U.S. Senate,,LIB,Dan Fitzgerald,3
+Lane,101523 EUGENE 523,U.S. Senate,,CONST,Lon Mabon,28
+Lane,101523 EUGENE 523,U.S. Senate,,DEM,Bill Bradbury,852
+Lane,101523 EUGENE 523,U.S. Senate,,REP,Gordon H. Smith,1485
+Lane,101523 EUGENE 523,U.S. Senate,,LIB,Dan Fitzgerald,38
+Lane,102402 SPRINGFIELD 402,U.S. Senate,,CONST,Lon Mabon,68
+Lane,102402 SPRINGFIELD 402,U.S. Senate,,DEM,Bill Bradbury,934
+Lane,102402 SPRINGFIELD 402,U.S. Senate,,REP,Gordon H. Smith,1409
+Lane,102402 SPRINGFIELD 402,U.S. Senate,,LIB,Dan Fitzgerald,77
+Lane,101809 EUGENE 809,U.S. Senate,,CONST,Lon Mabon,16
+Lane,101809 EUGENE 809,U.S. Senate,,DEM,Bill Bradbury,358
+Lane,101809 EUGENE 809,U.S. Senate,,REP,Gordon H. Smith,387
+Lane,101809 EUGENE 809,U.S. Senate,,LIB,Dan Fitzgerald,22
+Lane,102102 SPRINGFIELD 102,U.S. Senate,,CONST,Lon Mabon,41
+Lane,102102 SPRINGFIELD 102,U.S. Senate,,DEM,Bill Bradbury,919
+Lane,102102 SPRINGFIELD 102,U.S. Senate,,REP,Gordon H. Smith,1181
+Lane,102102 SPRINGFIELD 102,U.S. Senate,,LIB,Dan Fitzgerald,56
+Lane,102206 SPRINGFIELD 206,U.S. Senate,,CONST,Lon Mabon,63
+Lane,102206 SPRINGFIELD 206,U.S. Senate,,DEM,Bill Bradbury,1147
+Lane,102206 SPRINGFIELD 206,U.S. Senate,,REP,Gordon H. Smith,1218
+Lane,102206 SPRINGFIELD 206,U.S. Senate,,LIB,Dan Fitzgerald,94
+Lane,101713 EUGENE 713,U.S. Senate,,CONST,Lon Mabon,26
+Lane,101713 EUGENE 713,U.S. Senate,,DEM,Bill Bradbury,544
+Lane,101713 EUGENE 713,U.S. Senate,,REP,Gordon H. Smith,1055
+Lane,101713 EUGENE 713,U.S. Senate,,LIB,Dan Fitzgerald,21
+Lane,102608 SPRINGFIELD 608,U.S. Senate,,CONST,Lon Mabon,16
+Lane,102608 SPRINGFIELD 608,U.S. Senate,,DEM,Bill Bradbury,289
+Lane,102608 SPRINGFIELD 608,U.S. Senate,,REP,Gordon H. Smith,604
+Lane,102608 SPRINGFIELD 608,U.S. Senate,,LIB,Dan Fitzgerald,27
+Lane,101711 EUGENE 711,U.S. Senate,,CONST,Lon Mabon,17
+Lane,101711 EUGENE 711,U.S. Senate,,DEM,Bill Bradbury,316
+Lane,101711 EUGENE 711,U.S. Senate,,REP,Gordon H. Smith,219
+Lane,101711 EUGENE 711,U.S. Senate,,LIB,Dan Fitzgerald,38
+Lane,101807 EUGENE 807,U.S. Senate,,CONST,Lon Mabon,28
+Lane,101807 EUGENE 807,U.S. Senate,,DEM,Bill Bradbury,1366
+Lane,101807 EUGENE 807,U.S. Senate,,REP,Gordon H. Smith,1646
+Lane,101807 EUGENE 807,U.S. Senate,,LIB,Dan Fitzgerald,37
+Lane,101723 EUGENE 723,U.S. Senate,,CONST,Lon Mabon,38
+Lane,101723 EUGENE 723,U.S. Senate,,DEM,Bill Bradbury,1940
+Lane,101723 EUGENE 723,U.S. Senate,,REP,Gordon H. Smith,698
+Lane,101723 EUGENE 723,U.S. Senate,,LIB,Dan Fitzgerald,109
+Lane,101623 EUGENE 623,U.S. Senate,,CONST,Lon Mabon,43
+Lane,101623 EUGENE 623,U.S. Senate,,DEM,Bill Bradbury,715
+Lane,101623 EUGENE 623,U.S. Senate,,REP,Gordon H. Smith,1130
+Lane,101623 EUGENE 623,U.S. Senate,,LIB,Dan Fitzgerald,52
+Lane,101613 EUGENE 613,U.S. Senate,,CONST,Lon Mabon,44
+Lane,101613 EUGENE 613,U.S. Senate,,DEM,Bill Bradbury,1021
+Lane,101613 EUGENE 613,U.S. Senate,,REP,Gordon H. Smith,1185
+Lane,101613 EUGENE 613,U.S. Senate,,LIB,Dan Fitzgerald,66
+Lane,101805 EUGENE 805,U.S. Senate,,CONST,Lon Mabon,19
+Lane,101805 EUGENE 805,U.S. Senate,,DEM,Bill Bradbury,450
+Lane,101805 EUGENE 805,U.S. Senate,,REP,Gordon H. Smith,585
+Lane,101805 EUGENE 805,U.S. Senate,,LIB,Dan Fitzgerald,52
+Lane,101803 EUGENE 803,U.S. Senate,,CONST,Lon Mabon,17
+Lane,101803 EUGENE 803,U.S. Senate,,DEM,Bill Bradbury,678
+Lane,101803 EUGENE 803,U.S. Senate,,REP,Gordon H. Smith,420
+Lane,101803 EUGENE 803,U.S. Senate,,LIB,Dan Fitzgerald,38
+Lane,101719 EUGENE 719,U.S. Senate,,CONST,Lon Mabon,3
+Lane,101719 EUGENE 719,U.S. Senate,,DEM,Bill Bradbury,70
+Lane,101719 EUGENE 719,U.S. Senate,,REP,Gordon H. Smith,98
+Lane,101719 EUGENE 719,U.S. Senate,,LIB,Dan Fitzgerald,8
+Lane,102606 SPRINGFIELD 606,U.S. Senate,,CONST,Lon Mabon,51
+Lane,102606 SPRINGFIELD 606,U.S. Senate,,DEM,Bill Bradbury,724
+Lane,102606 SPRINGFIELD 606,U.S. Senate,,REP,Gordon H. Smith,1291
+Lane,102606 SPRINGFIELD 606,U.S. Senate,,LIB,Dan Fitzgerald,47
+Lane,101617 EUGENE 617,U.S. Senate,,CONST,Lon Mabon,50
+Lane,101617 EUGENE 617,U.S. Senate,,DEM,Bill Bradbury,804
+Lane,101617 EUGENE 617,U.S. Senate,,REP,Gordon H. Smith,1274
+Lane,101617 EUGENE 617,U.S. Senate,,LIB,Dan Fitzgerald,48
+Lane,101507 EUGENE 507,U.S. Senate,,CONST,Lon Mabon,25
+Lane,101507 EUGENE 507,U.S. Senate,,DEM,Bill Bradbury,570
+Lane,101507 EUGENE 507,U.S. Senate,,REP,Gordon H. Smith,811
+Lane,101507 EUGENE 507,U.S. Senate,,LIB,Dan Fitzgerald,34
+Lane,101715 EUGENE 715,U.S. Senate,,CONST,Lon Mabon,3
+Lane,101715 EUGENE 715,U.S. Senate,,DEM,Bill Bradbury,89
+Lane,101715 EUGENE 715,U.S. Senate,,REP,Gordon H. Smith,42
+Lane,101715 EUGENE 715,U.S. Senate,,LIB,Dan Fitzgerald,4
+Lane,102504 SPRINGFIELD 504,U.S. Senate,,CONST,Lon Mabon,48
+Lane,102504 SPRINGFIELD 504,U.S. Senate,,DEM,Bill Bradbury,806
+Lane,102504 SPRINGFIELD 504,U.S. Senate,,REP,Gordon H. Smith,1183
+Lane,102504 SPRINGFIELD 504,U.S. Senate,,LIB,Dan Fitzgerald,70
+Lane,100601 FLORENCE 1,U.S. House,4,DEM,Peter A. Defazio,1050
+Lane,100601 FLORENCE 1,U.S. House,4,LIB,Chris Bigelow,29
+Lane,100601 FLORENCE 1,U.S. House,4,REP,Liz Vanleeuwen,498
+Lane,100116 RIVER ROAD,U.S. House,4,DEM,Peter A. Defazio,2615
+Lane,100116 RIVER ROAD,U.S. House,4,LIB,Chris Bigelow,49
+Lane,100116 RIVER ROAD,U.S. House,4,REP,Liz Vanleeuwen,654
+Lane,100112 PLEASANT HILL 2,U.S. House,4,DEM,Peter A. Defazio,280
+Lane,100112 PLEASANT HILL 2,U.S. House,4,LIB,Chris Bigelow,9
+Lane,100112 PLEASANT HILL 2,U.S. House,4,REP,Liz Vanleeuwen,101
+Lane,101215 EUGENE 215,U.S. House,4,DEM,Peter A. Defazio,2351
+Lane,101215 EUGENE 215,U.S. House,4,LIB,Chris Bigelow,38
+Lane,101215 EUGENE 215,U.S. House,4,REP,Liz Vanleeuwen,415
+Lane,100105 MARCOLA,U.S. House,4,DEM,Peter A. Defazio,543
+Lane,100105 MARCOLA,U.S. House,4,LIB,Chris Bigelow,6
+Lane,100105 MARCOLA,U.S. House,4,REP,Liz Vanleeuwen,199
+Lane,100130 SIUSLAW,U.S. House,4,DEM,Peter A. Defazio,968
+Lane,100130 SIUSLAW,U.S. House,4,LIB,Chris Bigelow,18
+Lane,100130 SIUSLAW,U.S. House,4,REP,Liz Vanleeuwen,450
+Lane,101439 EUGENE 439,U.S. House,4,DEM,Peter A. Defazio,1623
+Lane,101439 EUGENE 439,U.S. House,4,LIB,Chris Bigelow,15
+Lane,101439 EUGENE 439,U.S. House,4,REP,Liz Vanleeuwen,819
+Lane,100087 GLENADA,U.S. House,4,DEM,Peter A. Defazio,590
+Lane,100087 GLENADA,U.S. House,4,LIB,Chris Bigelow,14
+Lane,100087 GLENADA,U.S. House,4,REP,Liz Vanleeuwen,231
+Lane,100128 SANTA CLARA 8,U.S. House,4,DEM,Peter A. Defazio,1178
+Lane,100128 SANTA CLARA 8,U.S. House,4,LIB,Chris Bigelow,25
+Lane,100128 SANTA CLARA 8,U.S. House,4,REP,Liz Vanleeuwen,462
+Lane,101223 EUGENE 223,U.S. House,4,DEM,Peter A. Defazio,2009
+Lane,101223 EUGENE 223,U.S. House,4,LIB,Chris Bigelow,32
+Lane,101223 EUGENE 223,U.S. House,4,REP,Liz Vanleeuwen,363
+Lane,101505 EUGENE 505,U.S. House,4,DEM,Peter A. Defazio,189
+Lane,101505 EUGENE 505,U.S. House,4,LIB,Chris Bigelow,2
+Lane,101505 EUGENE 505,U.S. House,4,REP,Liz Vanleeuwen,132
+Lane,100103 MAPLETON,U.S. House,4,DEM,Peter A. Defazio,425
+Lane,100103 MAPLETON,U.S. House,4,LIB,Chris Bigelow,9
+Lane,100103 MAPLETON,U.S. House,4,REP,Liz Vanleeuwen,184
+Lane,100007 BLUE RIVER,U.S. House,4,DEM,Peter A. Defazio,725
+Lane,100007 BLUE RIVER,U.S. House,4,LIB,Chris Bigelow,17
+Lane,100007 BLUE RIVER,U.S. House,4,REP,Liz Vanleeuwen,276
+Lane,100001 ALVADORE,U.S. House,4,DEM,Peter A. Defazio,732
+Lane,100001 ALVADORE,U.S. House,4,LIB,Chris Bigelow,10
+Lane,100001 ALVADORE,U.S. House,4,REP,Liz Vanleeuwen,386
+Lane,100012 CHESHIRE,U.S. House,4,DEM,Peter A. Defazio,1244
+Lane,100012 CHESHIRE,U.S. House,4,LIB,Chris Bigelow,26
+Lane,100012 CHESHIRE,U.S. House,4,REP,Liz Vanleeuwen,947
+Lane,101435 EUGENE 435,U.S. House,4,DEM,Peter A. Defazio,1494
+Lane,101435 EUGENE 435,U.S. House,4,LIB,Chris Bigelow,31
+Lane,101435 EUGENE 435,U.S. House,4,REP,Liz Vanleeuwen,578
+Lane,101317 EUGENE 317,U.S. House,4,DEM,Peter A. Defazio,2081
+Lane,101317 EUGENE 317,U.S. House,4,LIB,Chris Bigelow,31
+Lane,101317 EUGENE 317,U.S. House,4,REP,Liz Vanleeuwen,198
+Lane,100107 MOSBY,U.S. House,4,DEM,Peter A. Defazio,1403
+Lane,100107 MOSBY,U.S. House,4,LIB,Chris Bigelow,35
+Lane,100107 MOSBY,U.S. House,4,REP,Liz Vanleeuwen,787
+Lane,101101 EUGENE 101,U.S. House,4,DEM,Peter A. Defazio,2399
+Lane,101101 EUGENE 101,U.S. House,4,LIB,Chris Bigelow,32
+Lane,101101 EUGENE 101,U.S. House,4,REP,Liz Vanleeuwen,477
+Lane,100084 FOX HOLLOW,U.S. House,4,DEM,Peter A. Defazio,764
+Lane,100084 FOX HOLLOW,U.S. House,4,LIB,Chris Bigelow,10
+Lane,100084 FOX HOLLOW,U.S. House,4,REP,Liz Vanleeuwen,229
+Lane,100008 COAST FORK,U.S. House,4,DEM,Peter A. Defazio,761
+Lane,100008 COAST FORK,U.S. House,4,LIB,Chris Bigelow,24
+Lane,100008 COAST FORK,U.S. House,4,REP,Liz Vanleeuwen,461
+Lane,100111 PLEASANT HILL 1,U.S. House,4,DEM,Peter A. Defazio,1499
+Lane,100111 PLEASANT HILL 1,U.S. House,4,LIB,Chris Bigelow,30
+Lane,100111 PLEASANT HILL 1,U.S. House,4,REP,Liz Vanleeuwen,847
+Lane,101117 EUGENE 117,U.S. House,4,DEM,Peter A. Defazio,646
+Lane,101117 EUGENE 117,U.S. House,4,LIB,Chris Bigelow,13
+Lane,101117 EUGENE 117,U.S. House,4,REP,Liz Vanleeuwen,30
+Lane,101433 EUGENE 433,U.S. House,4,DEM,Peter A. Defazio,1177
+Lane,101433 EUGENE 433,U.S. House,4,LIB,Chris Bigelow,24
+Lane,101433 EUGENE 433,U.S. House,4,REP,Liz Vanleeuwen,386
+Lane,100100 LORANE,U.S. House,4,DEM,Peter A. Defazio,616
+Lane,100100 LORANE,U.S. House,4,LIB,Chris Bigelow,17
+Lane,100100 LORANE,U.S. House,4,REP,Liz Vanleeuwen,337
+Lane,100400 CRESWELL,U.S. House,4,DEM,Peter A. Defazio,616
+Lane,100400 CRESWELL,U.S. House,4,LIB,Chris Bigelow,8
+Lane,100400 CRESWELL,U.S. House,4,REP,Liz Vanleeuwen,385
+Lane,100155 MCKENZIE,U.S. House,4,DEM,Peter A. Defazio,1458
+Lane,100155 MCKENZIE,U.S. House,4,LIB,Chris Bigelow,38
+Lane,100155 MCKENZIE,U.S. House,4,REP,Liz Vanleeuwen,750
+Lane,100900 VENETA,U.S. House,4,DEM,Peter A. Defazio,513
+Lane,100900 VENETA,U.S. House,4,LIB,Chris Bigelow,16
+Lane,100900 VENETA,U.S. House,4,REP,Liz Vanleeuwen,282
+Lane,100800 OAKRIDGE,U.S. House,4,DEM,Peter A. Defazio,709
+Lane,100800 OAKRIDGE,U.S. House,4,LIB,Chris Bigelow,13
+Lane,100800 OAKRIDGE,U.S. House,4,REP,Liz Vanleeuwen,268
+Lane,100124 SANTA CLARA 4,U.S. House,4,DEM,Peter A. Defazio,1973
+Lane,100124 SANTA CLARA 4,U.S. House,4,LIB,Chris Bigelow,32
+Lane,100124 SANTA CLARA 4,U.S. House,4,REP,Liz Vanleeuwen,826
+Lane,100091 GROVEDALE,U.S. House,4,DEM,Peter A. Defazio,527
+Lane,100091 GROVEDALE,U.S. House,4,LIB,Chris Bigelow,3
+Lane,100091 GROVEDALE,U.S. House,4,REP,Liz Vanleeuwen,205
+Lane,100004 BAILEY,U.S. House,4,DEM,Peter A. Defazio,768
+Lane,100004 BAILEY,U.S. House,4,LIB,Chris Bigelow,11
+Lane,100004 BAILEY,U.S. House,4,REP,Liz Vanleeuwen,363
+Lane,100090 GOSHEN,U.S. House,4,DEM,Peter A. Defazio,1042
+Lane,100090 GOSHEN,U.S. House,4,LIB,Chris Bigelow,23
+Lane,100090 GOSHEN,U.S. House,4,REP,Liz Vanleeuwen,442
+Lane,100003 ARMITAGE,U.S. House,4,DEM,Peter A. Defazio,537
+Lane,100003 ARMITAGE,U.S. House,4,LIB,Chris Bigelow,9
+Lane,100003 ARMITAGE,U.S. House,4,REP,Liz Vanleeuwen,209
+Lane,100200 COBURG,U.S. House,4,DEM,Peter A. Defazio,286
+Lane,100200 COBURG,U.S. House,4,LIB,Chris Bigelow,4
+Lane,100200 COBURG,U.S. House,4,REP,Liz Vanleeuwen,98
+Lane,101237 EUGENE 237,U.S. House,4,DEM,Peter A. Defazio,1831
+Lane,101237 EUGENE 237,U.S. House,4,LIB,Chris Bigelow,20
+Lane,101237 EUGENE 237,U.S. House,4,REP,Liz Vanleeuwen,391
+Lane,101315 EUGENE 315,U.S. House,4,DEM,Peter A. Defazio,1904
+Lane,101315 EUGENE 315,U.S. House,4,LIB,Chris Bigelow,19
+Lane,101315 EUGENE 315,U.S. House,4,REP,Liz Vanleeuwen,218
+Lane,100095 GATEWAY,U.S. House,4,DEM,Peter A. Defazio,527
+Lane,100095 GATEWAY,U.S. House,4,LIB,Chris Bigelow,12
+Lane,100095 GATEWAY,U.S. House,4,REP,Liz Vanleeuwen,186
+Lane,100080 ELMIRA,U.S. House,4,DEM,Peter A. Defazio,1093
+Lane,100080 ELMIRA,U.S. House,4,LIB,Chris Bigelow,32
+Lane,100080 ELMIRA,U.S. House,4,REP,Liz Vanleeuwen,499
+Lane,100152 WALTERVILLE,U.S. House,4,DEM,Peter A. Defazio,1039
+Lane,100152 WALTERVILLE,U.S. House,4,LIB,Chris Bigelow,23
+Lane,100152 WALTERVILLE,U.S. House,4,REP,Liz Vanleeuwen,540
+Lane,101105 EUGENE 105,U.S. House,4,DEM,Peter A. Defazio,462
+Lane,101105 EUGENE 105,U.S. House,4,LIB,Chris Bigelow,11
+Lane,101105 EUGENE 105,U.S. House,4,REP,Liz Vanleeuwen,43
+Lane,100602 FLORENCE 2,U.S. House,4,DEM,Peter A. Defazio,1163
+Lane,100602 FLORENCE 2,U.S. House,4,LIB,Chris Bigelow,21
+Lane,100602 FLORENCE 2,U.S. House,4,REP,Liz Vanleeuwen,640
+Lane,100300 COTTAGE GROVE,U.S. House,4,DEM,Peter A. Defazio,1722
+Lane,100300 COTTAGE GROVE,U.S. House,4,LIB,Chris Bigelow,47
+Lane,100300 COTTAGE GROVE,U.S. House,4,REP,Liz Vanleeuwen,864
+Lane,100121 SANTA CLARA 1,U.S. House,4,DEM,Peter A. Defazio,642
+Lane,100121 SANTA CLARA 1,U.S. House,4,LIB,Chris Bigelow,15
+Lane,100121 SANTA CLARA 1,U.S. House,4,REP,Liz Vanleeuwen,261
+Lane,101313 EUGENE 313,U.S. House,4,DEM,Peter A. Defazio,1019
+Lane,101313 EUGENE 313,U.S. House,4,LIB,Chris Bigelow,43
+Lane,101313 EUGENE 313,U.S. House,4,REP,Liz Vanleeuwen,119
+Lane,101107 EUGENE 107,U.S. House,4,DEM,Peter A. Defazio,462
+Lane,101107 EUGENE 107,U.S. House,4,LIB,Chris Bigelow,15
+Lane,101107 EUGENE 107,U.S. House,4,REP,Liz Vanleeuwen,30
+Lane,101431 EUGENE 431,U.S. House,4,DEM,Peter A. Defazio,527
+Lane,101431 EUGENE 431,U.S. House,4,LIB,Chris Bigelow,9
+Lane,101431 EUGENE 431,U.S. House,4,REP,Liz Vanleeuwen,167
+Lane,100119 SALMON CREEK,U.S. House,4,DEM,Peter A. Defazio,351
+Lane,100119 SALMON CREEK,U.S. House,4,LIB,Chris Bigelow,7
+Lane,100119 SALMON CREEK,U.S. House,4,REP,Liz Vanleeuwen,169
+Lane,100009 CAMAS,U.S. House,4,DEM,Peter A. Defazio,200
+Lane,100009 CAMAS,U.S. House,4,LIB,Chris Bigelow,10
+Lane,100009 CAMAS,U.S. House,4,REP,Liz Vanleeuwen,108
+Lane,100086 GARDEN WAY,U.S. House,4,DEM,Peter A. Defazio,219
+Lane,100086 GARDEN WAY,U.S. House,4,LIB,Chris Bigelow,8
+Lane,100086 GARDEN WAY,U.S. House,4,REP,Liz Vanleeuwen,36
+Lane,100082 FERNRIDGE,U.S. House,4,DEM,Peter A. Defazio,903
+Lane,100082 FERNRIDGE,U.S. House,4,LIB,Chris Bigelow,28
+Lane,100082 FERNRIDGE,U.S. House,4,REP,Liz Vanleeuwen,434
+Lane,101235 EUGENE 235,U.S. House,4,DEM,Peter A. Defazio,1690
+Lane,101235 EUGENE 235,U.S. House,4,LIB,Chris Bigelow,28
+Lane,101235 EUGENE 235,U.S. House,4,REP,Liz Vanleeuwen,177
+Lane,100005 BLACHLY,U.S. House,4,DEM,Peter A. Defazio,612
+Lane,100005 BLACHLY,U.S. House,4,LIB,Chris Bigelow,21
+Lane,100005 BLACHLY,U.S. House,4,REP,Liz Vanleeuwen,235
+Lane,100102 LOWELL,U.S. House,4,DEM,Peter A. Defazio,587
+Lane,100102 LOWELL,U.S. House,4,LIB,Chris Bigelow,12
+Lane,100102 LOWELL,U.S. House,4,REP,Liz Vanleeuwen,252
+Lane,101103 EUGENE 103,U.S. House,4,DEM,Peter A. Defazio,2641
+Lane,101103 EUGENE 103,U.S. House,4,LIB,Chris Bigelow,37
+Lane,101103 EUGENE 103,U.S. House,4,REP,Liz Vanleeuwen,208
+Lane,100097 LATHAM,U.S. House,4,DEM,Peter A. Defazio,809
+Lane,100097 LATHAM,U.S. House,4,LIB,Chris Bigelow,28
+Lane,100097 LATHAM,U.S. House,4,REP,Liz Vanleeuwen,492
+Lane,100700 JUNCTION CITY,U.S. House,4,DEM,Peter A. Defazio,823
+Lane,100700 JUNCTION CITY,U.S. House,4,LIB,Chris Bigelow,17
+Lane,100700 JUNCTION CITY,U.S. House,4,REP,Liz Vanleeuwen,558
+Lane,101109 EUGENE 109,U.S. House,4,DEM,Peter A. Defazio,50
+Lane,101109 EUGENE 109,U.S. House,4,LIB,Chris Bigelow,1
+Lane,101109 EUGENE 109,U.S. House,4,REP,Liz Vanleeuwen,11
+Lane,100153 WILKINS,U.S. House,4,DEM,Peter A. Defazio,740
+Lane,100153 WILKINS,U.S. House,4,LIB,Chris Bigelow,13
+Lane,100153 WILKINS,U.S. House,4,REP,Liz Vanleeuwen,407
+Lane,100500 DUNES CITY,U.S. House,4,DEM,Peter A. Defazio,443
+Lane,100500 DUNES CITY,U.S. House,4,LIB,Chris Bigelow,10
+Lane,100500 DUNES CITY,U.S. House,4,REP,Liz Vanleeuwen,212
+Lane,101511 EUGENE 511,U.S. House,4,DEM,Peter A. Defazio,2184
+Lane,101511 EUGENE 511,U.S. House,4,LIB,Chris Bigelow,39
+Lane,101511 EUGENE 511,U.S. House,4,REP,Liz Vanleeuwen,914
+Lane,102304 SPRINGFIELD 304,U.S. House,4,DEM,Peter A. Defazio,1932
+Lane,102304 SPRINGFIELD 304,U.S. House,4,LIB,Chris Bigelow,48
+Lane,102304 SPRINGFIELD 304,U.S. House,4,REP,Liz Vanleeuwen,626
+Lane,101717 EUGENE 717,U.S. House,4,DEM,Peter A. Defazio,138
+Lane,101717 EUGENE 717,U.S. House,4,LIB,Chris Bigelow,2
+Lane,101717 EUGENE 717,U.S. House,4,REP,Liz Vanleeuwen,21
+Lane,101523 EUGENE 523,U.S. House,4,DEM,Peter A. Defazio,1513
+Lane,101523 EUGENE 523,U.S. House,4,LIB,Chris Bigelow,27
+Lane,101523 EUGENE 523,U.S. House,4,REP,Liz Vanleeuwen,848
+Lane,102402 SPRINGFIELD 402,U.S. House,4,DEM,Peter A. Defazio,1742
+Lane,102402 SPRINGFIELD 402,U.S. House,4,LIB,Chris Bigelow,48
+Lane,102402 SPRINGFIELD 402,U.S. House,4,REP,Liz Vanleeuwen,707
+Lane,101809 EUGENE 809,U.S. House,4,DEM,Peter A. Defazio,555
+Lane,101809 EUGENE 809,U.S. House,4,LIB,Chris Bigelow,18
+Lane,101809 EUGENE 809,U.S. House,4,REP,Liz Vanleeuwen,216
+Lane,102102 SPRINGFIELD 102,U.S. House,4,DEM,Peter A. Defazio,1541
+Lane,102102 SPRINGFIELD 102,U.S. House,4,LIB,Chris Bigelow,49
+Lane,102102 SPRINGFIELD 102,U.S. House,4,REP,Liz Vanleeuwen,615
+Lane,102206 SPRINGFIELD 206,U.S. House,4,DEM,Peter A. Defazio,1882
+Lane,102206 SPRINGFIELD 206,U.S. House,4,LIB,Chris Bigelow,60
+Lane,102206 SPRINGFIELD 206,U.S. House,4,REP,Liz Vanleeuwen,573
+Lane,101713 EUGENE 713,U.S. House,4,DEM,Peter A. Defazio,1021
+Lane,101713 EUGENE 713,U.S. House,4,LIB,Chris Bigelow,18
+Lane,101713 EUGENE 713,U.S. House,4,REP,Liz Vanleeuwen,599
+Lane,102608 SPRINGFIELD 608,U.S. House,4,DEM,Peter A. Defazio,575
+Lane,102608 SPRINGFIELD 608,U.S. House,4,LIB,Chris Bigelow,15
+Lane,102608 SPRINGFIELD 608,U.S. House,4,REP,Liz Vanleeuwen,339
+Lane,101711 EUGENE 711,U.S. House,4,DEM,Peter A. Defazio,480
+Lane,101711 EUGENE 711,U.S. House,4,LIB,Chris Bigelow,15
+Lane,101711 EUGENE 711,U.S. House,4,REP,Liz Vanleeuwen,95
+Lane,101807 EUGENE 807,U.S. House,4,DEM,Peter A. Defazio,2134
+Lane,101807 EUGENE 807,U.S. House,4,LIB,Chris Bigelow,34
+Lane,101807 EUGENE 807,U.S. House,4,REP,Liz Vanleeuwen,886
+Lane,101723 EUGENE 723,U.S. House,4,DEM,Peter A. Defazio,2381
+Lane,101723 EUGENE 723,U.S. House,4,LIB,Chris Bigelow,58
+Lane,101723 EUGENE 723,U.S. House,4,REP,Liz Vanleeuwen,354
+Lane,101623 EUGENE 623,U.S. House,4,DEM,Peter A. Defazio,1280
+Lane,101623 EUGENE 623,U.S. House,4,LIB,Chris Bigelow,28
+Lane,101623 EUGENE 623,U.S. House,4,REP,Liz Vanleeuwen,636
+Lane,101613 EUGENE 613,U.S. House,4,DEM,Peter A. Defazio,1714
+Lane,101613 EUGENE 613,U.S. House,4,LIB,Chris Bigelow,36
+Lane,101613 EUGENE 613,U.S. House,4,REP,Liz Vanleeuwen,574
+Lane,101805 EUGENE 805,U.S. House,4,DEM,Peter A. Defazio,795
+Lane,101805 EUGENE 805,U.S. House,4,LIB,Chris Bigelow,27
+Lane,101805 EUGENE 805,U.S. House,4,REP,Liz Vanleeuwen,286
+Lane,101803 EUGENE 803,U.S. House,4,DEM,Peter A. Defazio,929
+Lane,101803 EUGENE 803,U.S. House,4,LIB,Chris Bigelow,21
+Lane,101803 EUGENE 803,U.S. House,4,REP,Liz Vanleeuwen,206
+Lane,101719 EUGENE 719,U.S. House,4,DEM,Peter A. Defazio,136
+Lane,101719 EUGENE 719,U.S. House,4,LIB,Chris Bigelow,1
+Lane,101719 EUGENE 719,U.S. House,4,REP,Liz Vanleeuwen,42
+Lane,102606 SPRINGFIELD 606,U.S. House,4,DEM,Peter A. Defazio,1472
+Lane,102606 SPRINGFIELD 606,U.S. House,4,LIB,Chris Bigelow,27
+Lane,102606 SPRINGFIELD 606,U.S. House,4,REP,Liz Vanleeuwen,624
+Lane,101617 EUGENE 617,U.S. House,4,DEM,Peter A. Defazio,1455
+Lane,101617 EUGENE 617,U.S. House,4,LIB,Chris Bigelow,32
+Lane,101617 EUGENE 617,U.S. House,4,REP,Liz Vanleeuwen,679
+Lane,101507 EUGENE 507,U.S. House,4,DEM,Peter A. Defazio,920
+Lane,101507 EUGENE 507,U.S. House,4,LIB,Chris Bigelow,26
+Lane,101507 EUGENE 507,U.S. House,4,REP,Liz Vanleeuwen,498
+Lane,101715 EUGENE 715,U.S. House,4,DEM,Peter A. Defazio,122
+Lane,101715 EUGENE 715,U.S. House,4,LIB,Chris Bigelow,4
+Lane,101715 EUGENE 715,U.S. House,4,REP,Liz Vanleeuwen,18
+Lane,102504 SPRINGFIELD 504,U.S. House,4,DEM,Peter A. Defazio,1534
+Lane,102504 SPRINGFIELD 504,U.S. House,4,LIB,Chris Bigelow,35
+Lane,102504 SPRINGFIELD 504,U.S. House,4,REP,Liz Vanleeuwen,573
+Lane,100601 FLORENCE 1,Governor,,REP,Kevin L. Mannix,668
+Lane,100601 FLORENCE 1,Governor,,LIB,Tom Cox,70
+Lane,100601 FLORENCE 1,Governor,,DEM,Ted Kulongoski,797
+Lane,100116 RIVER ROAD,Governor,,REP,Kevin L. Mannix,989
+Lane,100116 RIVER ROAD,Governor,,LIB,Tom Cox,155
+Lane,100116 RIVER ROAD,Governor,,DEM,Ted Kulongoski,2130
+Lane,100112 PLEASANT HILL 2,Governor,,REP,Kevin L. Mannix,143
+Lane,100112 PLEASANT HILL 2,Governor,,LIB,Tom Cox,18
+Lane,100112 PLEASANT HILL 2,Governor,,DEM,Ted Kulongoski,224
+Lane,101215 EUGENE 215,Governor,,REP,Kevin L. Mannix,640
+Lane,101215 EUGENE 215,Governor,,LIB,Tom Cox,83
+Lane,101215 EUGENE 215,Governor,,DEM,Ted Kulongoski,2077
+Lane,100105 MARCOLA,Governor,,REP,Kevin L. Mannix,314
+Lane,100105 MARCOLA,Governor,,LIB,Tom Cox,27
+Lane,100105 MARCOLA,Governor,,DEM,Ted Kulongoski,398
+Lane,100130 SIUSLAW,Governor,,REP,Kevin L. Mannix,607
+Lane,100130 SIUSLAW,Governor,,LIB,Tom Cox,69
+Lane,100130 SIUSLAW,Governor,,DEM,Ted Kulongoski,735
+Lane,101439 EUGENE 439,Governor,,REP,Kevin L. Mannix,1140
+Lane,101439 EUGENE 439,Governor,,LIB,Tom Cox,59
+Lane,101439 EUGENE 439,Governor,,DEM,Ted Kulongoski,1236
+Lane,100087 GLENADA,Governor,,REP,Kevin L. Mannix,350
+Lane,100087 GLENADA,Governor,,LIB,Tom Cox,31
+Lane,100087 GLENADA,Governor,,DEM,Ted Kulongoski,441
+Lane,100128 SANTA CLARA 8,Governor,,REP,Kevin L. Mannix,645
+Lane,100128 SANTA CLARA 8,Governor,,LIB,Tom Cox,77
+Lane,100128 SANTA CLARA 8,Governor,,DEM,Ted Kulongoski,911
+Lane,101223 EUGENE 223,Governor,,REP,Kevin L. Mannix,543
+Lane,101223 EUGENE 223,Governor,,LIB,Tom Cox,75
+Lane,101223 EUGENE 223,Governor,,DEM,Ted Kulongoski,1784
+Lane,101505 EUGENE 505,Governor,,REP,Kevin L. Mannix,174
+Lane,101505 EUGENE 505,Governor,,LIB,Tom Cox,12
+Lane,101505 EUGENE 505,Governor,,DEM,Ted Kulongoski,142
+Lane,100103 MAPLETON,Governor,,REP,Kevin L. Mannix,237
+Lane,100103 MAPLETON,Governor,,LIB,Tom Cox,31
+Lane,100103 MAPLETON,Governor,,DEM,Ted Kulongoski,344
+Lane,100007 BLUE RIVER,Governor,,REP,Kevin L. Mannix,423
+Lane,100007 BLUE RIVER,Governor,,LIB,Tom Cox,42
+Lane,100007 BLUE RIVER,Governor,,DEM,Ted Kulongoski,541
+Lane,100001 ALVADORE,Governor,,REP,Kevin L. Mannix,575
+Lane,100001 ALVADORE,Governor,,LIB,Tom Cox,51
+Lane,100001 ALVADORE,Governor,,DEM,Ted Kulongoski,500
+Lane,100012 CHESHIRE,Governor,,REP,Kevin L. Mannix,1206
+Lane,100012 CHESHIRE,Governor,,LIB,Tom Cox,92
+Lane,100012 CHESHIRE,Governor,,DEM,Ted Kulongoski,892
+Lane,101435 EUGENE 435,Governor,,REP,Kevin L. Mannix,863
+Lane,101435 EUGENE 435,Governor,,LIB,Tom Cox,73
+Lane,101435 EUGENE 435,Governor,,DEM,Ted Kulongoski,1153
+Lane,101317 EUGENE 317,Governor,,REP,Kevin L. Mannix,272
+Lane,101317 EUGENE 317,Governor,,LIB,Tom Cox,50
+Lane,101317 EUGENE 317,Governor,,DEM,Ted Kulongoski,1975
+Lane,100107 MOSBY,Governor,,REP,Kevin L. Mannix,1095
+Lane,100107 MOSBY,Governor,,LIB,Tom Cox,115
+Lane,100107 MOSBY,Governor,,DEM,Ted Kulongoski,974
+Lane,101101 EUGENE 101,Governor,,REP,Kevin L. Mannix,678
+Lane,101101 EUGENE 101,Governor,,LIB,Tom Cox,90
+Lane,101101 EUGENE 101,Governor,,DEM,Ted Kulongoski,2119
+Lane,100084 FOX HOLLOW,Governor,,REP,Kevin L. Mannix,333
+Lane,100084 FOX HOLLOW,Governor,,LIB,Tom Cox,36
+Lane,100084 FOX HOLLOW,Governor,,DEM,Ted Kulongoski,616
+Lane,100008 COAST FORK,Governor,,REP,Kevin L. Mannix,688
+Lane,100008 COAST FORK,Governor,,LIB,Tom Cox,55
+Lane,100008 COAST FORK,Governor,,DEM,Ted Kulongoski,501
+Lane,100111 PLEASANT HILL 1,Governor,,REP,Kevin L. Mannix,1167
+Lane,100111 PLEASANT HILL 1,Governor,,LIB,Tom Cox,113
+Lane,100111 PLEASANT HILL 1,Governor,,DEM,Ted Kulongoski,1058
+Lane,101117 EUGENE 117,Governor,,REP,Kevin L. Mannix,48
+Lane,101117 EUGENE 117,Governor,,LIB,Tom Cox,27
+Lane,101117 EUGENE 117,Governor,,DEM,Ted Kulongoski,609
+Lane,101433 EUGENE 433,Governor,,REP,Kevin L. Mannix,569
+Lane,101433 EUGENE 433,Governor,,LIB,Tom Cox,50
+Lane,101433 EUGENE 433,Governor,,DEM,Ted Kulongoski,962
+Lane,100100 LORANE,Governor,,REP,Kevin L. Mannix,449
+Lane,100100 LORANE,Governor,,LIB,Tom Cox,50
+Lane,100100 LORANE,Governor,,DEM,Ted Kulongoski,465
+Lane,100400 CRESWELL,Governor,,REP,Kevin L. Mannix,529
+Lane,100400 CRESWELL,Governor,,LIB,Tom Cox,35
+Lane,100400 CRESWELL,Governor,,DEM,Ted Kulongoski,436
+Lane,100155 MCKENZIE,Governor,,REP,Kevin L. Mannix,1134
+Lane,100155 MCKENZIE,Governor,,LIB,Tom Cox,121
+Lane,100155 MCKENZIE,Governor,,DEM,Ted Kulongoski,964
+Lane,100900 VENETA,Governor,,REP,Kevin L. Mannix,385
+Lane,100900 VENETA,Governor,,LIB,Tom Cox,46
+Lane,100900 VENETA,Governor,,DEM,Ted Kulongoski,375
+Lane,100800 OAKRIDGE,Governor,,REP,Kevin L. Mannix,369
+Lane,100800 OAKRIDGE,Governor,,LIB,Tom Cox,49
+Lane,100800 OAKRIDGE,Governor,,DEM,Ted Kulongoski,544
+Lane,100124 SANTA CLARA 4,Governor,,REP,Kevin L. Mannix,1264
+Lane,100124 SANTA CLARA 4,Governor,,LIB,Tom Cox,124
+Lane,100124 SANTA CLARA 4,Governor,,DEM,Ted Kulongoski,1415
+Lane,100091 GROVEDALE,Governor,,REP,Kevin L. Mannix,293
+Lane,100091 GROVEDALE,Governor,,LIB,Tom Cox,27
+Lane,100091 GROVEDALE,Governor,,DEM,Ted Kulongoski,400
+Lane,100004 BAILEY,Governor,,REP,Kevin L. Mannix,504
+Lane,100004 BAILEY,Governor,,LIB,Tom Cox,53
+Lane,100004 BAILEY,Governor,,DEM,Ted Kulongoski,580
+Lane,100090 GOSHEN,Governor,,REP,Kevin L. Mannix,610
+Lane,100090 GOSHEN,Governor,,LIB,Tom Cox,83
+Lane,100090 GOSHEN,Governor,,DEM,Ted Kulongoski,791
+Lane,100003 ARMITAGE,Governor,,REP,Kevin L. Mannix,346
+Lane,100003 ARMITAGE,Governor,,LIB,Tom Cox,33
+Lane,100003 ARMITAGE,Governor,,DEM,Ted Kulongoski,369
+Lane,100200 COBURG,Governor,,REP,Kevin L. Mannix,162
+Lane,100200 COBURG,Governor,,LIB,Tom Cox,16
+Lane,100200 COBURG,Governor,,DEM,Ted Kulongoski,214
+Lane,101237 EUGENE 237,Governor,,REP,Kevin L. Mannix,568
+Lane,101237 EUGENE 237,Governor,,LIB,Tom Cox,45
+Lane,101237 EUGENE 237,Governor,,DEM,Ted Kulongoski,1615
+Lane,101315 EUGENE 315,Governor,,REP,Kevin L. Mannix,257
+Lane,101315 EUGENE 315,Governor,,LIB,Tom Cox,49
+Lane,101315 EUGENE 315,Governor,,DEM,Ted Kulongoski,1826
+Lane,100095 GATEWAY,Governor,,REP,Kevin L. Mannix,286
+Lane,100095 GATEWAY,Governor,,LIB,Tom Cox,44
+Lane,100095 GATEWAY,Governor,,DEM,Ted Kulongoski,383
+Lane,100080 ELMIRA,Governor,,REP,Kevin L. Mannix,728
+Lane,100080 ELMIRA,Governor,,LIB,Tom Cox,83
+Lane,100080 ELMIRA,Governor,,DEM,Ted Kulongoski,789
+Lane,100152 WALTERVILLE,Governor,,REP,Kevin L. Mannix,824
+Lane,100152 WALTERVILLE,Governor,,LIB,Tom Cox,61
+Lane,100152 WALTERVILLE,Governor,,DEM,Ted Kulongoski,698
+Lane,101105 EUGENE 105,Governor,,REP,Kevin L. Mannix,80
+Lane,101105 EUGENE 105,Governor,,LIB,Tom Cox,33
+Lane,101105 EUGENE 105,Governor,,DEM,Ted Kulongoski,402
+Lane,100602 FLORENCE 2,Governor,,REP,Kevin L. Mannix,820
+Lane,100602 FLORENCE 2,Governor,,LIB,Tom Cox,78
+Lane,100602 FLORENCE 2,Governor,,DEM,Ted Kulongoski,899
+Lane,100300 COTTAGE GROVE,Governor,,REP,Kevin L. Mannix,1186
+Lane,100300 COTTAGE GROVE,Governor,,LIB,Tom Cox,161
+Lane,100300 COTTAGE GROVE,Governor,,DEM,Ted Kulongoski,1243
+Lane,100121 SANTA CLARA 1,Governor,,REP,Kevin L. Mannix,393
+Lane,100121 SANTA CLARA 1,Governor,,LIB,Tom Cox,56
+Lane,100121 SANTA CLARA 1,Governor,,DEM,Ted Kulongoski,445
+Lane,101313 EUGENE 313,Governor,,REP,Kevin L. Mannix,154
+Lane,101313 EUGENE 313,Governor,,LIB,Tom Cox,67
+Lane,101313 EUGENE 313,Governor,,DEM,Ted Kulongoski,953
+Lane,101107 EUGENE 107,Governor,,REP,Kevin L. Mannix,40
+Lane,101107 EUGENE 107,Governor,,LIB,Tom Cox,25
+Lane,101107 EUGENE 107,Governor,,DEM,Ted Kulongoski,431
+Lane,101431 EUGENE 431,Governor,,REP,Kevin L. Mannix,222
+Lane,101431 EUGENE 431,Governor,,LIB,Tom Cox,23
+Lane,101431 EUGENE 431,Governor,,DEM,Ted Kulongoski,453
+Lane,100119 SALMON CREEK,Governor,,REP,Kevin L. Mannix,243
+Lane,100119 SALMON CREEK,Governor,,LIB,Tom Cox,34
+Lane,100119 SALMON CREEK,Governor,,DEM,Ted Kulongoski,248
+Lane,100009 CAMAS,Governor,,REP,Kevin L. Mannix,153
+Lane,100009 CAMAS,Governor,,LIB,Tom Cox,14
+Lane,100009 CAMAS,Governor,,DEM,Ted Kulongoski,147
+Lane,100086 GARDEN WAY,Governor,,REP,Kevin L. Mannix,72
+Lane,100086 GARDEN WAY,Governor,,LIB,Tom Cox,20
+Lane,100086 GARDEN WAY,Governor,,DEM,Ted Kulongoski,165
+Lane,100082 FERNRIDGE,Governor,,REP,Kevin L. Mannix,634
+Lane,100082 FERNRIDGE,Governor,,LIB,Tom Cox,74
+Lane,100082 FERNRIDGE,Governor,,DEM,Ted Kulongoski,650
+Lane,101235 EUGENE 235,Governor,,REP,Kevin L. Mannix,262
+Lane,101235 EUGENE 235,Governor,,LIB,Tom Cox,61
+Lane,101235 EUGENE 235,Governor,,DEM,Ted Kulongoski,1536
+Lane,100005 BLACHLY,Governor,,REP,Kevin L. Mannix,326
+Lane,100005 BLACHLY,Governor,,LIB,Tom Cox,78
+Lane,100005 BLACHLY,Governor,,DEM,Ted Kulongoski,463
+Lane,100102 LOWELL,Governor,,REP,Kevin L. Mannix,359
+Lane,100102 LOWELL,Governor,,LIB,Tom Cox,61
+Lane,100102 LOWELL,Governor,,DEM,Ted Kulongoski,404
+Lane,101103 EUGENE 103,Governor,,REP,Kevin L. Mannix,316
+Lane,101103 EUGENE 103,Governor,,LIB,Tom Cox,87
+Lane,101103 EUGENE 103,Governor,,DEM,Ted Kulongoski,2461
+Lane,100097 LATHAM,Governor,,REP,Kevin L. Mannix,693
+Lane,100097 LATHAM,Governor,,LIB,Tom Cox,77
+Lane,100097 LATHAM,Governor,,DEM,Ted Kulongoski,539
+Lane,100700 JUNCTION CITY,Governor,,REP,Kevin L. Mannix,716
+Lane,100700 JUNCTION CITY,Governor,,LIB,Tom Cox,46
+Lane,100700 JUNCTION CITY,Governor,,DEM,Ted Kulongoski,610
+Lane,101109 EUGENE 109,Governor,,REP,Kevin L. Mannix,15
+Lane,101109 EUGENE 109,Governor,,LIB,Tom Cox,3
+Lane,101109 EUGENE 109,Governor,,DEM,Ted Kulongoski,45
+Lane,100153 WILKINS,Governor,,REP,Kevin L. Mannix,534
+Lane,100153 WILKINS,Governor,,LIB,Tom Cox,64
+Lane,100153 WILKINS,Governor,,DEM,Ted Kulongoski,549
+Lane,100500 DUNES CITY,Governor,,REP,Kevin L. Mannix,316
+Lane,100500 DUNES CITY,Governor,,LIB,Tom Cox,28
+Lane,100500 DUNES CITY,Governor,,DEM,Ted Kulongoski,314
+Lane,101511 EUGENE 511,Governor,,REP,Kevin L. Mannix,1320
+Lane,101511 EUGENE 511,Governor,,LIB,Tom Cox,98
+Lane,101511 EUGENE 511,Governor,,DEM,Ted Kulongoski,1689
+Lane,102304 SPRINGFIELD 304,Governor,,REP,Kevin L. Mannix,969
+Lane,102304 SPRINGFIELD 304,Governor,,LIB,Tom Cox,179
+Lane,102304 SPRINGFIELD 304,Governor,,DEM,Ted Kulongoski,1396
+Lane,101717 EUGENE 717,Governor,,REP,Kevin L. Mannix,37
+Lane,101717 EUGENE 717,Governor,,LIB,Tom Cox,4
+Lane,101717 EUGENE 717,Governor,,DEM,Ted Kulongoski,117
+Lane,101523 EUGENE 523,Governor,,REP,Kevin L. Mannix,1212
+Lane,101523 EUGENE 523,Governor,,LIB,Tom Cox,62
+Lane,101523 EUGENE 523,Governor,,DEM,Ted Kulongoski,1099
+Lane,102402 SPRINGFIELD 402,Governor,,REP,Kevin L. Mannix,1052
+Lane,102402 SPRINGFIELD 402,Governor,,LIB,Tom Cox,174
+Lane,102402 SPRINGFIELD 402,Governor,,DEM,Ted Kulongoski,1225
+Lane,101809 EUGENE 809,Governor,,REP,Kevin L. Mannix,295
+Lane,101809 EUGENE 809,Governor,,LIB,Tom Cox,33
+Lane,101809 EUGENE 809,Governor,,DEM,Ted Kulongoski,450
+Lane,102102 SPRINGFIELD 102,Governor,,REP,Kevin L. Mannix,914
+Lane,102102 SPRINGFIELD 102,Governor,,LIB,Tom Cox,105
+Lane,102102 SPRINGFIELD 102,Governor,,DEM,Ted Kulongoski,1151
+Lane,102206 SPRINGFIELD 206,Governor,,REP,Kevin L. Mannix,919
+Lane,102206 SPRINGFIELD 206,Governor,,LIB,Tom Cox,168
+Lane,102206 SPRINGFIELD 206,Governor,,DEM,Ted Kulongoski,1404
+Lane,101713 EUGENE 713,Governor,,REP,Kevin L. Mannix,846
+Lane,101713 EUGENE 713,Governor,,LIB,Tom Cox,60
+Lane,101713 EUGENE 713,Governor,,DEM,Ted Kulongoski,733
+Lane,102608 SPRINGFIELD 608,Governor,,REP,Kevin L. Mannix,485
+Lane,102608 SPRINGFIELD 608,Governor,,LIB,Tom Cox,38
+Lane,102608 SPRINGFIELD 608,Governor,,DEM,Ted Kulongoski,395
+Lane,101711 EUGENE 711,Governor,,REP,Kevin L. Mannix,162
+Lane,101711 EUGENE 711,Governor,,LIB,Tom Cox,52
+Lane,101711 EUGENE 711,Governor,,DEM,Ted Kulongoski,365
+Lane,101807 EUGENE 807,Governor,,REP,Kevin L. Mannix,1272
+Lane,101807 EUGENE 807,Governor,,LIB,Tom Cox,77
+Lane,101807 EUGENE 807,Governor,,DEM,Ted Kulongoski,1686
+Lane,101723 EUGENE 723,Governor,,REP,Kevin L. Mannix,505
+Lane,101723 EUGENE 723,Governor,,LIB,Tom Cox,149
+Lane,101723 EUGENE 723,Governor,,DEM,Ted Kulongoski,2107
+Lane,101623 EUGENE 623,Governor,,REP,Kevin L. Mannix,870
+Lane,101623 EUGENE 623,Governor,,LIB,Tom Cox,122
+Lane,101623 EUGENE 623,Governor,,DEM,Ted Kulongoski,926
+Lane,101613 EUGENE 613,Governor,,REP,Kevin L. Mannix,902
+Lane,101613 EUGENE 613,Governor,,LIB,Tom Cox,106
+Lane,101613 EUGENE 613,Governor,,DEM,Ted Kulongoski,1261
+Lane,101805 EUGENE 805,Governor,,REP,Kevin L. Mannix,458
+Lane,101805 EUGENE 805,Governor,,LIB,Tom Cox,85
+Lane,101805 EUGENE 805,Governor,,DEM,Ted Kulongoski,554
+Lane,101803 EUGENE 803,Governor,,REP,Kevin L. Mannix,317
+Lane,101803 EUGENE 803,Governor,,LIB,Tom Cox,68
+Lane,101803 EUGENE 803,Governor,,DEM,Ted Kulongoski,761
+Lane,101719 EUGENE 719,Governor,,REP,Kevin L. Mannix,71
+Lane,101719 EUGENE 719,Governor,,LIB,Tom Cox,7
+Lane,101719 EUGENE 719,Governor,,DEM,Ted Kulongoski,94
+Lane,102606 SPRINGFIELD 606,Governor,,REP,Kevin L. Mannix,1021
+Lane,102606 SPRINGFIELD 606,Governor,,LIB,Tom Cox,90
+Lane,102606 SPRINGFIELD 606,Governor,,DEM,Ted Kulongoski,974
+Lane,101617 EUGENE 617,Governor,,REP,Kevin L. Mannix,1016
+Lane,101617 EUGENE 617,Governor,,LIB,Tom Cox,108
+Lane,101617 EUGENE 617,Governor,,DEM,Ted Kulongoski,1032
+Lane,101507 EUGENE 507,Governor,,REP,Kevin L. Mannix,653
+Lane,101507 EUGENE 507,Governor,,LIB,Tom Cox,53
+Lane,101507 EUGENE 507,Governor,,DEM,Ted Kulongoski,729
+Lane,101715 EUGENE 715,Governor,,REP,Kevin L. Mannix,25
+Lane,101715 EUGENE 715,Governor,,LIB,Tom Cox,3
+Lane,101715 EUGENE 715,Governor,,DEM,Ted Kulongoski,108
+Lane,102504 SPRINGFIELD 504,Governor,,REP,Kevin L. Mannix,928
+Lane,102504 SPRINGFIELD 504,Governor,,LIB,Tom Cox,138
+Lane,102504 SPRINGFIELD 504,Governor,,DEM,Ted Kulongoski,1022
+Lane,101235 EUGENE 235,State Senate,4,DEM,Tony Corcoran,1506
+Lane,101235 EUGENE 235,State Senate,4,REP,David Alsup,275
+Lane,100112 PLEASANT HILL 2,State Senate,4,DEM,Tony Corcoran,229
+Lane,100112 PLEASANT HILL 2,State Senate,4,REP,David Alsup,137
+Lane,100900 VENETA,State Senate,4,DEM,Tony Corcoran,396
+Lane,100900 VENETA,State Senate,4,REP,David Alsup,375
+Lane,100300 COTTAGE GROVE,State Senate,4,DEM,Tony Corcoran,1484
+Lane,100300 COTTAGE GROVE,State Senate,4,REP,David Alsup,1063
+Lane,100007 BLUE RIVER,State Senate,4,DEM,Tony Corcoran,592
+Lane,100007 BLUE RIVER,State Senate,4,REP,David Alsup,393
+Lane,101101 EUGENE 101,State Senate,4,DEM,Tony Corcoran,2008
+Lane,101101 EUGENE 101,State Senate,4,REP,David Alsup,672
+Lane,101809 EUGENE 809,State Senate,4,DEM,Tony Corcoran,426
+Lane,101809 EUGENE 809,State Senate,4,REP,David Alsup,295
+Lane,100084 FOX HOLLOW,State Senate,4,DEM,Tony Corcoran,622
+Lane,100084 FOX HOLLOW,State Senate,4,REP,David Alsup,312
+Lane,100100 LORANE,State Senate,4,DEM,Tony Corcoran,477
+Lane,100100 LORANE,State Senate,4,REP,David Alsup,452
+Lane,101237 EUGENE 237,State Senate,4,DEM,Tony Corcoran,1527
+Lane,101237 EUGENE 237,State Senate,4,REP,David Alsup,547
+Lane,100800 OAKRIDGE,State Senate,4,DEM,Tony Corcoran,615
+Lane,100800 OAKRIDGE,State Senate,4,REP,David Alsup,331
+Lane,100004 BAILEY,State Senate,4,DEM,Tony Corcoran,546
+Lane,100004 BAILEY,State Senate,4,REP,David Alsup,500
+Lane,100107 MOSBY,State Senate,4,DEM,Tony Corcoran,1188
+Lane,100107 MOSBY,State Senate,4,REP,David Alsup,949
+Lane,101807 EUGENE 807,State Senate,4,DEM,Tony Corcoran,1655
+Lane,101807 EUGENE 807,State Senate,4,REP,David Alsup,1173
+Lane,101315 EUGENE 315,State Senate,4,DEM,Tony Corcoran,1731
+Lane,101315 EUGENE 315,State Senate,4,REP,David Alsup,269
+Lane,101313 EUGENE 313,State Senate,4,DEM,Tony Corcoran,897
+Lane,101313 EUGENE 313,State Senate,4,REP,David Alsup,150
+Lane,101717 EUGENE 717,State Senate,4,DEM,Tony Corcoran,120
+Lane,101717 EUGENE 717,State Senate,4,REP,David Alsup,31
+Lane,100119 SALMON CREEK,State Senate,4,DEM,Tony Corcoran,283
+Lane,100119 SALMON CREEK,State Senate,4,REP,David Alsup,230
+Lane,100009 CAMAS,State Senate,4,DEM,Tony Corcoran,155
+Lane,100009 CAMAS,State Senate,4,REP,David Alsup,140
+Lane,100082 FERNRIDGE,State Senate,4,DEM,Tony Corcoran,655
+Lane,100082 FERNRIDGE,State Senate,4,REP,David Alsup,605
+Lane,100102 LOWELL,State Senate,4,DEM,Tony Corcoran,431
+Lane,100102 LOWELL,State Senate,4,REP,David Alsup,369
+Lane,101103 EUGENE 103,State Senate,4,DEM,Tony Corcoran,2399
+Lane,101103 EUGENE 103,State Senate,4,REP,David Alsup,319
+Lane,101715 EUGENE 715,State Senate,4,DEM,Tony Corcoran,99
+Lane,101715 EUGENE 715,State Senate,4,REP,David Alsup,29
+Lane,100097 LATHAM,State Senate,4,DEM,Tony Corcoran,669
+Lane,100097 LATHAM,State Senate,4,REP,David Alsup,606
+Lane,101215 EUGENE 215,State Senate,6,DEM,Bill Morrisette,2023
+Lane,102304 SPRINGFIELD 304,State Senate,6,DEM,Bill Morrisette,1911
+Lane,101439 EUGENE 439,State Senate,6,DEM,Bill Morrisette,0
+Lane,101223 EUGENE 223,State Senate,6,DEM,Bill Morrisette,1709
+Lane,101523 EUGENE 523,State Senate,6,DEM,Bill Morrisette,5
+Lane,101317 EUGENE 317,State Senate,6,DEM,Bill Morrisette,1746
+Lane,102402 SPRINGFIELD 402,State Senate,6,DEM,Bill Morrisette,1728
+Lane,100155 MCKENZIE,State Senate,6,DEM,Bill Morrisette,1386
+Lane,100105 MARCOLA,State Senate,6,DEM,Bill Morrisette,459
+Lane,100008 COAST FORK,State Senate,6,DEM,Bill Morrisette,689
+Lane,100111 PLEASANT HILL 1,State Senate,6,DEM,Bill Morrisette,1417
+Lane,102206 SPRINGFIELD 206,State Senate,6,DEM,Bill Morrisette,1846
+Lane,100400 CRESWELL,State Senate,6,DEM,Bill Morrisette,587
+Lane,102608 SPRINGFIELD 608,State Senate,6,DEM,Bill Morrisette,583
+Lane,100091 GROVEDALE,State Senate,6,DEM,Bill Morrisette,521
+Lane,100152 WALTERVILLE,State Senate,6,DEM,Bill Morrisette,1007
+Lane,100090 GOSHEN,State Senate,6,DEM,Bill Morrisette,998
+Lane,100003 ARMITAGE,State Senate,6,DEM,Bill Morrisette,518
+Lane,100200 COBURG,State Senate,6,DEM,Bill Morrisette,266
+Lane,100095 GATEWAY,State Senate,6,DEM,Bill Morrisette,524
+Lane,102102 SPRINGFIELD 102,State Senate,6,DEM,Bill Morrisette,1593
+Lane,100086 GARDEN WAY,State Senate,6,DEM,Bill Morrisette,203
+Lane,102606 SPRINGFIELD 606,State Senate,6,DEM,Bill Morrisette,1416
+Lane,102504 SPRINGFIELD 504,State Senate,6,DEM,Bill Morrisette,1514
+Lane,100153 WILKINS,State Senate,6,DEM,Bill Morrisette,701
+Lane,101109 EUGENE 109,State Senate,7,DEM,Vicki L. Walker,45
+Lane,101109 EUGENE 109,State Senate,7,REP,Mike Cary,16
+Lane,101511 EUGENE 511,State Senate,7,DEM,Vicki L. Walker,1559
+Lane,101511 EUGENE 511,State Senate,7,REP,Mike Cary,1476
+Lane,101439 EUGENE 439,State Senate,7,DEM,Vicki L. Walker,1148
+Lane,101439 EUGENE 439,State Senate,7,REP,Mike Cary,1199
+Lane,101803 EUGENE 803,State Senate,7,DEM,Vicki L. Walker,763
+Lane,101803 EUGENE 803,State Senate,7,REP,Mike Cary,334
+Lane,100128 SANTA CLARA 8,State Senate,7,DEM,Vicki L. Walker,820
+Lane,100128 SANTA CLARA 8,State Senate,7,REP,Mike Cary,756
+Lane,101505 EUGENE 505,State Senate,7,DEM,Vicki L. Walker,119
+Lane,101505 EUGENE 505,State Senate,7,REP,Mike Cary,183
+Lane,101523 EUGENE 523,State Senate,7,DEM,Vicki L. Walker,997
+Lane,101523 EUGENE 523,State Senate,7,REP,Mike Cary,1320
+Lane,100001 ALVADORE,State Senate,7,DEM,Vicki L. Walker,444
+Lane,100001 ALVADORE,State Senate,7,REP,Mike Cary,590
+Lane,100012 CHESHIRE,State Senate,7,DEM,Vicki L. Walker,816
+Lane,100012 CHESHIRE,State Senate,7,REP,Mike Cary,1265
+Lane,101435 EUGENE 435,State Senate,7,DEM,Vicki L. Walker,1028
+Lane,101435 EUGENE 435,State Senate,7,REP,Mike Cary,1004
+Lane,101317 EUGENE 317,State Senate,7,DEM,Vicki L. Walker,0
+Lane,101317 EUGENE 317,State Senate,7,REP,Mike Cary,0
+Lane,101107 EUGENE 107,State Senate,7,DEM,Vicki L. Walker,429
+Lane,101107 EUGENE 107,State Senate,7,REP,Mike Cary,46
+Lane,101117 EUGENE 117,State Senate,7,DEM,Vicki L. Walker,594
+Lane,101117 EUGENE 117,State Senate,7,REP,Mike Cary,60
+Lane,101433 EUGENE 433,State Senate,7,DEM,Vicki L. Walker,880
+Lane,101433 EUGENE 433,State Senate,7,REP,Mike Cary,645
+Lane,101431 EUGENE 431,State Senate,7,DEM,Vicki L. Walker,434
+Lane,101431 EUGENE 431,State Senate,7,REP,Mike Cary,237
+Lane,101713 EUGENE 713,State Senate,7,DEM,Vicki L. Walker,637
+Lane,101713 EUGENE 713,State Senate,7,REP,Mike Cary,933
+Lane,100124 SANTA CLARA 4,State Senate,7,DEM,Vicki L. Walker,1324
+Lane,100124 SANTA CLARA 4,State Senate,7,REP,Mike Cary,1350
+Lane,100116 RIVER ROAD,State Senate,7,DEM,Vicki L. Walker,2084
+Lane,100116 RIVER ROAD,State Senate,7,REP,Mike Cary,1048
+Lane,101711 EUGENE 711,State Senate,7,DEM,Vicki L. Walker,376
+Lane,101711 EUGENE 711,State Senate,7,REP,Mike Cary,174
+Lane,101723 EUGENE 723,State Senate,7,DEM,Vicki L. Walker,2096
+Lane,101723 EUGENE 723,State Senate,7,REP,Mike Cary,563
+Lane,101105 EUGENE 105,State Senate,7,DEM,Vicki L. Walker,407
+Lane,101105 EUGENE 105,State Senate,7,REP,Mike Cary,78
+Lane,101623 EUGENE 623,State Senate,7,DEM,Vicki L. Walker,857
+Lane,101623 EUGENE 623,State Senate,7,REP,Mike Cary,961
+Lane,101613 EUGENE 613,State Senate,7,DEM,Vicki L. Walker,1199
+Lane,101613 EUGENE 613,State Senate,7,REP,Mike Cary,975
+Lane,100121 SANTA CLARA 1,State Senate,7,DEM,Vicki L. Walker,423
+Lane,100121 SANTA CLARA 1,State Senate,7,REP,Mike Cary,435
+Lane,101719 EUGENE 719,State Senate,7,DEM,Vicki L. Walker,82
+Lane,101719 EUGENE 719,State Senate,7,REP,Mike Cary,82
+Lane,101617 EUGENE 617,State Senate,7,DEM,Vicki L. Walker,973
+Lane,101617 EUGENE 617,State Senate,7,REP,Mike Cary,1063
+Lane,101507 EUGENE 507,State Senate,7,DEM,Vicki L. Walker,676
+Lane,101507 EUGENE 507,State Senate,7,REP,Mike Cary,715
+Lane,101715 EUGENE 715,State Senate,7,DEM,Vicki L. Walker,0
+Lane,101715 EUGENE 715,State Senate,7,REP,Mike Cary,0
+Lane,100700 JUNCTION CITY,State Senate,7,DEM,Vicki L. Walker,542
+Lane,100700 JUNCTION CITY,State Senate,7,REP,Mike Cary,770
+Lane,101805 EUGENE 805,State Senate,7,DEM,Vicki L. Walker,543
+Lane,101805 EUGENE 805,State Senate,7,REP,Mike Cary,482
+Lane,100119 SALMON CREEK,State House,7,DEM,Donald Nordin,212
+Lane,100119 SALMON CREEK,State House,7,REP,Jeff Kruse,246
+Lane,100112 PLEASANT HILL 2,State House,7,DEM,Donald Nordin,206
+Lane,100112 PLEASANT HILL 2,State House,7,REP,Jeff Kruse,145
+Lane,100107 MOSBY,State House,7,DEM,Donald Nordin,846
+Lane,100107 MOSBY,State House,7,REP,Jeff Kruse,1213
+Lane,100009 CAMAS,State House,7,DEM,Donald Nordin,119
+Lane,100009 CAMAS,State House,7,REP,Jeff Kruse,160
+Lane,100007 BLUE RIVER,State House,7,DEM,Donald Nordin,459
+Lane,100007 BLUE RIVER,State House,7,REP,Jeff Kruse,487
+Lane,100300 COTTAGE GROVE,State House,7,DEM,Donald Nordin,1087
+Lane,100300 COTTAGE GROVE,State House,7,REP,Jeff Kruse,1359
+Lane,100102 LOWELL,State House,7,DEM,Donald Nordin,381
+Lane,100102 LOWELL,State House,7,REP,Jeff Kruse,390
+Lane,100097 LATHAM,State House,7,DEM,Donald Nordin,459
+Lane,100097 LATHAM,State House,7,REP,Jeff Kruse,770
+Lane,100800 OAKRIDGE,State House,7,DEM,Donald Nordin,464
+Lane,100800 OAKRIDGE,State House,7,REP,Jeff Kruse,414
+Lane,101101 EUGENE 101,State House,8,REP,Greg McNeill,586
+Lane,101101 EUGENE 101,State House,8,DEM,Floyd Prozanski,2016
+Lane,101235 EUGENE 235,State House,8,REP,Greg McNeill,235
+Lane,101235 EUGENE 235,State House,8,DEM,Floyd Prozanski,1524
+Lane,100004 BAILEY,State House,8,REP,Greg McNeill,476
+Lane,100004 BAILEY,State House,8,DEM,Floyd Prozanski,527
+Lane,100084 FOX HOLLOW,State House,8,REP,Greg McNeill,281
+Lane,100084 FOX HOLLOW,State House,8,DEM,Floyd Prozanski,606
+Lane,100082 FERNRIDGE,State House,8,REP,Greg McNeill,549
+Lane,100082 FERNRIDGE,State House,8,DEM,Floyd Prozanski,613
+Lane,101807 EUGENE 807,State House,8,REP,Greg McNeill,1104
+Lane,101807 EUGENE 807,State House,8,DEM,Floyd Prozanski,1641
+Lane,100900 VENETA,State House,8,REP,Greg McNeill,357
+Lane,100900 VENETA,State House,8,DEM,Floyd Prozanski,357
+Lane,101315 EUGENE 315,State House,8,REP,Greg McNeill,246
+Lane,101315 EUGENE 315,State House,8,DEM,Floyd Prozanski,1738
+Lane,100100 LORANE,State House,8,REP,Greg McNeill,387
+Lane,100100 LORANE,State House,8,DEM,Floyd Prozanski,455
+Lane,101715 EUGENE 715,State House,8,REP,Greg McNeill,18
+Lane,101715 EUGENE 715,State House,8,DEM,Floyd Prozanski,101
+Lane,101809 EUGENE 809,State House,8,REP,Greg McNeill,281
+Lane,101809 EUGENE 809,State House,8,DEM,Floyd Prozanski,412
+Lane,101237 EUGENE 237,State House,8,REP,Greg McNeill,488
+Lane,101237 EUGENE 237,State House,8,DEM,Floyd Prozanski,1556
+Lane,101103 EUGENE 103,State House,8,REP,Greg McNeill,276
+Lane,101103 EUGENE 103,State House,8,DEM,Floyd Prozanski,2454
+Lane,101313 EUGENE 313,State House,8,REP,Greg McNeill,147
+Lane,101313 EUGENE 313,State House,8,DEM,Floyd Prozanski,876
+Lane,101717 EUGENE 717,State House,8,REP,Greg McNeill,33
+Lane,101717 EUGENE 717,State House,8,DEM,Floyd Prozanski,113
+Lane,100601 FLORENCE 1,State House,9,,Valorie K. Holloway,314
+Lane,100601 FLORENCE 1,State House,9,,Joanne Verger,964
+Lane,100087 GLENADA,State House,9,,Valorie K. Holloway,169
+Lane,100087 GLENADA,State House,9,,Joanne Verger,477
+Lane,100500 DUNES CITY,State House,9,,Valorie K. Holloway,178
+Lane,100500 DUNES CITY,State House,9,,Joanne Verger,373
+Lane,100602 FLORENCE 2,State House,9,,Valorie K. Holloway,369
+Lane,100602 FLORENCE 2,State House,9,,Joanne Verger,1093
+Lane,100130 SIUSLAW,State House,10,,Alan Brown,705
+Lane,100130 SIUSLAW,State House,10,,Marcia L. Thompson,670
+Lane,100005 BLACHLY,State House,10,,Alan Brown,361
+Lane,100005 BLACHLY,State House,10,,Marcia L. Thompson,451
+Lane,100103 MAPLETON,State House,10,,Alan Brown,246
+Lane,100103 MAPLETON,State House,10,,Marcia L. Thompson,332
+Lane,100080 ELMIRA,State House,10,,Alan Brown,755
+Lane,100080 ELMIRA,State House,10,,Marcia L. Thompson,756
+Lane,100091 GROVEDALE,State House,11,REP,Robert M. Bolanos,241
+Lane,100091 GROVEDALE,State House,11,DEM,Phil Barnhart,410
+Lane,100152 WALTERVILLE,State House,11,REP,Robert M. Bolanos,641
+Lane,100152 WALTERVILLE,State House,11,DEM,Phil Barnhart,748
+Lane,100090 GOSHEN,State House,11,REP,Robert M. Bolanos,480
+Lane,100090 GOSHEN,State House,11,DEM,Phil Barnhart,820
+Lane,101215 EUGENE 215,State House,11,REP,Robert M. Bolanos,487
+Lane,101215 EUGENE 215,State House,11,DEM,Phil Barnhart,2064
+Lane,100008 COAST FORK,State House,11,REP,Robert M. Bolanos,540
+Lane,100008 COAST FORK,State House,11,DEM,Phil Barnhart,553
+Lane,100105 MARCOLA,State House,11,REP,Robert M. Bolanos,258
+Lane,100105 MARCOLA,State House,11,DEM,Phil Barnhart,406
+Lane,101439 EUGENE 439,State House,11,REP,Robert M. Bolanos,0
+Lane,101439 EUGENE 439,State House,11,DEM,Phil Barnhart,0
+Lane,100111 PLEASANT HILL 1,State House,11,REP,Robert M. Bolanos,960
+Lane,100111 PLEASANT HILL 1,State House,11,DEM,Phil Barnhart,1071
+Lane,102102 SPRINGFIELD 102,State House,11,REP,Robert M. Bolanos,6
+Lane,102102 SPRINGFIELD 102,State House,11,DEM,Phil Barnhart,3
+Lane,100200 COBURG,State House,11,REP,Robert M. Bolanos,122
+Lane,100200 COBURG,State House,11,DEM,Phil Barnhart,212
+Lane,101223 EUGENE 223,State House,11,REP,Robert M. Bolanos,408
+Lane,101223 EUGENE 223,State House,11,DEM,Phil Barnhart,1786
+Lane,102504 SPRINGFIELD 504,State House,11,REP,Robert M. Bolanos,0
+Lane,102504 SPRINGFIELD 504,State House,11,DEM,Phil Barnhart,1
+Lane,101523 EUGENE 523,State House,11,REP,Robert M. Bolanos,0
+Lane,101523 EUGENE 523,State House,11,DEM,Phil Barnhart,3
+Lane,100400 CRESWELL,State House,11,REP,Robert M. Bolanos,447
+Lane,100400 CRESWELL,State House,11,DEM,Phil Barnhart,446
+Lane,101317 EUGENE 317,State House,11,REP,Robert M. Bolanos,234
+Lane,101317 EUGENE 317,State House,11,DEM,Phil Barnhart,1953
+Lane,100153 WILKINS,State House,11,REP,Robert M. Bolanos,439
+Lane,100153 WILKINS,State House,11,DEM,Phil Barnhart,538
+Lane,100155 MCKENZIE,State House,11,REP,Robert M. Bolanos,904
+Lane,100155 MCKENZIE,State House,11,DEM,Phil Barnhart,1023
+Lane,100003 ARMITAGE,State House,12,DEM,Elizabeth Terry Beyer,371
+Lane,100003 ARMITAGE,State House,12,REP,Norm Fox,336
+Lane,102304 SPRINGFIELD 304,State House,12,DEM,Elizabeth Terry Beyer,1365
+Lane,102304 SPRINGFIELD 304,State House,12,REP,Norm Fox,1048
+Lane,100086 GARDEN WAY,State House,12,DEM,Elizabeth Terry Beyer,161
+Lane,100086 GARDEN WAY,State House,12,REP,Norm Fox,73
+Lane,102606 SPRINGFIELD 606,State House,12,DEM,Elizabeth Terry Beyer,996
+Lane,102606 SPRINGFIELD 606,State House,12,REP,Norm Fox,955
+Lane,102102 SPRINGFIELD 102,State House,12,DEM,Elizabeth Terry Beyer,1069
+Lane,102102 SPRINGFIELD 102,State House,12,REP,Norm Fox,977
+Lane,100095 GATEWAY,State House,12,DEM,Elizabeth Terry Beyer,362
+Lane,100095 GATEWAY,State House,12,REP,Norm Fox,310
+Lane,102206 SPRINGFIELD 206,State House,12,DEM,Elizabeth Terry Beyer,1369
+Lane,102206 SPRINGFIELD 206,State House,12,REP,Norm Fox,972
+Lane,102608 SPRINGFIELD 608,State House,12,DEM,Elizabeth Terry Beyer,388
+Lane,102608 SPRINGFIELD 608,State House,12,REP,Norm Fox,480
+Lane,102504 SPRINGFIELD 504,State House,12,DEM,Elizabeth Terry Beyer,967
+Lane,102504 SPRINGFIELD 504,State House,12,REP,Norm Fox,986
+Lane,102402 SPRINGFIELD 402,State House,12,DEM,Elizabeth Terry Beyer,1165
+Lane,102402 SPRINGFIELD 402,State House,12,REP,Norm Fox,1113
+Lane,100116 RIVER ROAD,State House,13,LIB,Jay Bozievich,674
+Lane,100116 RIVER ROAD,State House,13,DEM,Robert Ackerman,2142
+Lane,101435 EUGENE 435,State House,13,LIB,Jay Bozievich,500
+Lane,101435 EUGENE 435,State House,13,DEM,Robert Ackerman,1207
+Lane,101511 EUGENE 511,State House,13,LIB,Jay Bozievich,729
+Lane,101511 EUGENE 511,State House,13,DEM,Robert Ackerman,1772
+Lane,101107 EUGENE 107,State House,13,LIB,Jay Bozievich,82
+Lane,101107 EUGENE 107,State House,13,DEM,Robert Ackerman,364
+Lane,101719 EUGENE 719,State House,13,LIB,Jay Bozievich,32
+Lane,101719 EUGENE 719,State House,13,DEM,Robert Ackerman,111
+Lane,101439 EUGENE 439,State House,13,LIB,Jay Bozievich,529
+Lane,101439 EUGENE 439,State House,13,DEM,Robert Ackerman,1358
+Lane,101723 EUGENE 723,State House,13,LIB,Jay Bozievich,530
+Lane,101723 EUGENE 723,State House,13,DEM,Robert Ackerman,1899
+Lane,101117 EUGENE 117,State House,13,LIB,Jay Bozievich,121
+Lane,101117 EUGENE 117,State House,13,DEM,Robert Ackerman,500
+Lane,101433 EUGENE 433,State House,13,LIB,Jay Bozievich,345
+Lane,101433 EUGENE 433,State House,13,DEM,Robert Ackerman,955
+Lane,101507 EUGENE 507,State House,13,LIB,Jay Bozievich,338
+Lane,101507 EUGENE 507,State House,13,DEM,Robert Ackerman,810
+Lane,100128 SANTA CLARA 8,State House,13,LIB,Jay Bozievich,382
+Lane,100128 SANTA CLARA 8,State House,13,DEM,Robert Ackerman,971
+Lane,101715 EUGENE 715,State House,13,LIB,Jay Bozievich,0
+Lane,101715 EUGENE 715,State House,13,DEM,Robert Ackerman,0
+Lane,101431 EUGENE 431,State House,13,LIB,Jay Bozievich,136
+Lane,101431 EUGENE 431,State House,13,DEM,Robert Ackerman,453
+Lane,101523 EUGENE 523,State House,13,LIB,Jay Bozievich,612
+Lane,101523 EUGENE 523,State House,13,DEM,Robert Ackerman,1253
+Lane,101317 EUGENE 317,State House,13,LIB,Jay Bozievich,0
+Lane,101317 EUGENE 317,State House,13,DEM,Robert Ackerman,0
+Lane,101109 EUGENE 109,State House,14,DEM,Araminta Hawkins,43
+Lane,101109 EUGENE 109,State House,14,REP,Pat Farr,18
+Lane,101505 EUGENE 505,State House,14,DEM,Araminta Hawkins,138
+Lane,101505 EUGENE 505,State House,14,REP,Pat Farr,176
+Lane,101803 EUGENE 803,State House,14,DEM,Araminta Hawkins,747
+Lane,101803 EUGENE 803,State House,14,REP,Pat Farr,373
+Lane,101711 EUGENE 711,State House,14,DEM,Araminta Hawkins,377
+Lane,101711 EUGENE 711,State House,14,REP,Pat Farr,186
+Lane,101805 EUGENE 805,State House,14,DEM,Araminta Hawkins,542
+Lane,101805 EUGENE 805,State House,14,REP,Pat Farr,517
+Lane,101617 EUGENE 617,State House,14,DEM,Araminta Hawkins,891
+Lane,101617 EUGENE 617,State House,14,REP,Pat Farr,1237
+Lane,101623 EUGENE 623,State House,14,DEM,Araminta Hawkins,814
+Lane,101623 EUGENE 623,State House,14,REP,Pat Farr,1068
+Lane,101613 EUGENE 613,State House,14,DEM,Araminta Hawkins,1119
+Lane,101613 EUGENE 613,State House,14,REP,Pat Farr,1147
+Lane,100121 SANTA CLARA 1,State House,14,DEM,Araminta Hawkins,415
+Lane,100121 SANTA CLARA 1,State House,14,REP,Pat Farr,449
+Lane,100700 JUNCTION CITY,State House,14,DEM,Araminta Hawkins,524
+Lane,100700 JUNCTION CITY,State House,14,REP,Pat Farr,814
+Lane,101105 EUGENE 105,State House,14,DEM,Araminta Hawkins,404
+Lane,101105 EUGENE 105,State House,14,REP,Pat Farr,91
+Lane,100001 ALVADORE,State House,14,DEM,Araminta Hawkins,462
+Lane,100001 ALVADORE,State House,14,REP,Pat Farr,615
+Lane,100012 CHESHIRE,State House,14,DEM,Araminta Hawkins,799
+Lane,100012 CHESHIRE,State House,14,REP,Pat Farr,1330
+Lane,101713 EUGENE 713,State House,14,DEM,Araminta Hawkins,645
+Lane,101713 EUGENE 713,State House,14,REP,Pat Farr,955
+Lane,100124 SANTA CLARA 4,State House,14,DEM,Araminta Hawkins,1317
+Lane,100124 SANTA CLARA 4,State House,14,REP,Pat Farr,1401

--- a/2004/20040518__or__primary__lane__precinct.csv
+++ b/2004/20040518__or__primary__lane__precinct.csv
@@ -1,0 +1,4485 @@
+county,precinct,office,district,party,candidate,votes
+Lane,0033 5 MCKENZIE,President,,DEM,Lyndon H. Larouche Jr.,15
+Lane,0033 5 MCKENZIE,President,,DEM,John F. Kerry,465
+Lane,0033 5 MCKENZIE,President,,DEM,Dennis J. Kucinich,86
+Lane,0033 5 MCKENZIE,President,,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,President,,DEM,Under Votes,44
+Lane,0026 9 SALMON CREEK,President,,DEM,Lyndon H. Larouche Jr.,7
+Lane,0026 9 SALMON CREEK,President,,DEM,John F. Kerry,122
+Lane,0026 9 SALMON CREEK,President,,DEM,Dennis J. Kucinich,23
+Lane,0026 9 SALMON CREEK,President,,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,President,,DEM,Under Votes,8
+Lane,0013 7 GLENADA,President,,DEM,Lyndon H. Larouche Jr.,10
+Lane,0013 7 GLENADA,President,,DEM,John F. Kerry,242
+Lane,0013 7 GLENADA,President,,DEM,Dennis J. Kucinich,41
+Lane,0013 7 GLENADA,President,,DEM,Over Votes,0
+Lane,0013 7 GLENADA,President,,DEM,Under Votes,14
+Lane,0028 4 SANTA CLARA 4,President,,DEM,Lyndon H. Larouche Jr.,17
+Lane,0028 4 SANTA CLARA 4,President,,DEM,John F. Kerry,666
+Lane,0028 4 SANTA CLARA 4,President,,DEM,Dennis J. Kucinich,123
+Lane,0028 4 SANTA CLARA 4,President,,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,President,,DEM,Under Votes,45
+Lane,0010 2 FERNRIDGE,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0010 2 FERNRIDGE,President,,DEM,John F. Kerry,278
+Lane,0010 2 FERNRIDGE,President,,DEM,Dennis J. Kucinich,61
+Lane,0010 2 FERNRIDGE,President,,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,President,,DEM,Under Votes,20
+Lane,0002 3 ARMITAGE,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0002 3 ARMITAGE,President,,DEM,John F. Kerry,182
+Lane,0002 3 ARMITAGE,President,,DEM,Dennis J. Kucinich,29
+Lane,0002 3 ARMITAGE,President,,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,President,,DEM,Under Votes,24
+Lane,0030 0 SIUSLAW,President,,DEM,Lyndon H. Larouche Jr.,13
+Lane,0030 0 SIUSLAW,President,,DEM,John F. Kerry,366
+Lane,0030 0 SIUSLAW,President,,DEM,Dennis J. Kucinich,89
+Lane,0030 0 SIUSLAW,President,,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,President,,DEM,Under Votes,16
+Lane,0052 7 EUGENE 237,President,,DEM,Lyndon H. Larouche Jr.,7
+Lane,0052 7 EUGENE 237,President,,DEM,John F. Kerry,856
+Lane,0052 7 EUGENE 237,President,,DEM,Dennis J. Kucinich,269
+Lane,0052 7 EUGENE 237,President,,DEM,Over Votes,1
+Lane,0052 7 EUGENE 237,President,,DEM,Under Votes,31
+Lane,0004 5 BLACHLY,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0004 5 BLACHLY,President,,DEM,John F. Kerry,172
+Lane,0004 5 BLACHLY,President,,DEM,Dennis J. Kucinich,68
+Lane,0004 5 BLACHLY,President,,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,President,,DEM,Under Votes,16
+Lane,0035 0 COTTAGE GROVE,President,,DEM,Lyndon H. Larouche Jr.,26
+Lane,0035 0 COTTAGE GROVE,President,,DEM,John F. Kerry,627
+Lane,0035 0 COTTAGE GROVE,President,,DEM,Dennis J. Kucinich,174
+Lane,0035 0 COTTAGE GROVE,President,,DEM,Over Votes,1
+Lane,0035 0 COTTAGE GROVE,President,,DEM,Under Votes,63
+Lane,0049 5 EUGENE 215,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0049 5 EUGENE 215,President,,DEM,John F. Kerry,1010
+Lane,0049 5 EUGENE 215,President,,DEM,Dennis J. Kucinich,343
+Lane,0049 5 EUGENE 215,President,,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,President,,DEM,Under Votes,49
+Lane,0037 0 DUNES CITY,President,,DEM,Lyndon H. Larouche Jr.,3
+Lane,0037 0 DUNES CITY,President,,DEM,John F. Kerry,161
+Lane,0037 0 DUNES CITY,President,,DEM,Dennis J. Kucinich,26
+Lane,0037 0 DUNES CITY,President,,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,President,,DEM,Under Votes,8
+Lane,0042 0 VENETA,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0042 0 VENETA,President,,DEM,John F. Kerry,176
+Lane,0042 0 VENETA,President,,DEM,Dennis J. Kucinich,47
+Lane,0042 0 VENETA,President,,DEM,Over Votes,0
+Lane,0042 0 VENETA,President,,DEM,Under Votes,14
+Lane,0031 2 WALTERVILLE,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0031 2 WALTERVILLE,President,,DEM,John F. Kerry,366
+Lane,0031 2 WALTERVILLE,President,,DEM,Dennis J. Kucinich,68
+Lane,0031 2 WALTERVILLE,President,,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,President,,DEM,Under Votes,30
+Lane,0045 5 EUGENE 105,President,,DEM,Lyndon H. Larouche Jr.,3
+Lane,0045 5 EUGENE 105,President,,DEM,John F. Kerry,119
+Lane,0045 5 EUGENE 105,President,,DEM,Dennis J. Kucinich,76
+Lane,0045 5 EUGENE 105,President,,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,President,,DEM,Under Votes,3
+Lane,0024 2 PLEASANT HILL 2,President,,DEM,Lyndon H. Larouche Jr.,4
+Lane,0024 2 PLEASANT HILL 2,President,,DEM,John F. Kerry,103
+Lane,0024 2 PLEASANT HILL 2,President,,DEM,Dennis J. Kucinich,29
+Lane,0024 2 PLEASANT HILL 2,President,,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,President,,DEM,Under Votes,24
+Lane,0055 7 EUGENE 317,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0055 7 EUGENE 317,President,,DEM,John F. Kerry,949
+Lane,0055 7 EUGENE 317,President,,DEM,Dennis J. Kucinich,321
+Lane,0055 7 EUGENE 317,President,,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,President,,DEM,Under Votes,19
+Lane,0039 2 FLORENCE 2,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0039 2 FLORENCE 2,President,,DEM,John F. Kerry,495
+Lane,0039 2 FLORENCE 2,President,,DEM,Dennis J. Kucinich,70
+Lane,0039 2 FLORENCE 2,President,,DEM,Over Votes,1
+Lane,0039 2 FLORENCE 2,President,,DEM,Under Votes,26
+Lane,0029 8 SANTA CLARA 8,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0029 8 SANTA CLARA 8,President,,DEM,John F. Kerry,398
+Lane,0029 8 SANTA CLARA 8,President,,DEM,Dennis J. Kucinich,90
+Lane,0029 8 SANTA CLARA 8,President,,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,President,,DEM,Under Votes,23
+Lane,0046 7 EUGENE 107,President,,DEM,Lyndon H. Larouche Jr.,2
+Lane,0046 7 EUGENE 107,President,,DEM,John F. Kerry,143
+Lane,0046 7 EUGENE 107,President,,DEM,Dennis J. Kucinich,77
+Lane,0046 7 EUGENE 107,President,,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,President,,DEM,Under Votes,8
+Lane,0008 2 CHESHIRE,President,,DEM,Lyndon H. Larouche Jr.,17
+Lane,0008 2 CHESHIRE,President,,DEM,John F. Kerry,424
+Lane,0008 2 CHESHIRE,President,,DEM,Dennis J. Kucinich,99
+Lane,0008 2 CHESHIRE,President,,DEM,Over Votes,1
+Lane,0008 2 CHESHIRE,President,,DEM,Under Votes,35
+Lane,0027 1 SANTA CLARA 1,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0027 1 SANTA CLARA 1,President,,DEM,John F. Kerry,236
+Lane,0027 1 SANTA CLARA 1,President,,DEM,Dennis J. Kucinich,32
+Lane,0027 1 SANTA CLARA 1,President,,DEM,Over Votes,1
+Lane,0027 1 SANTA CLARA 1,President,,DEM,Under Votes,14
+Lane,0058 5 EUGENE 435,President,,DEM,Lyndon H. Larouche Jr.,8
+Lane,0058 5 EUGENE 435,President,,DEM,John F. Kerry,597
+Lane,0058 5 EUGENE 435,President,,DEM,Dennis J. Kucinich,124
+Lane,0058 5 EUGENE 435,President,,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,President,,DEM,Under Votes,44
+Lane,0014 0 GOSHEN,President,,DEM,Lyndon H. Larouche Jr.,11
+Lane,0014 0 GOSHEN,President,,DEM,John F. Kerry,330
+Lane,0014 0 GOSHEN,President,,DEM,Dennis J. Kucinich,122
+Lane,0014 0 GOSHEN,President,,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,President,,DEM,Under Votes,25
+Lane,0018 0 LORANE,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0018 0 LORANE,President,,DEM,John F. Kerry,193
+Lane,0018 0 LORANE,President,,DEM,Dennis J. Kucinich,106
+Lane,0018 0 LORANE,President,,DEM,Over Votes,0
+Lane,0018 0 LORANE,President,,DEM,Under Votes,13
+Lane,0003 4 BAILEY,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0003 4 BAILEY,President,,DEM,John F. Kerry,234
+Lane,0003 4 BAILEY,President,,DEM,Dennis J. Kucinich,75
+Lane,0003 4 BAILEY,President,,DEM,Over Votes,1
+Lane,0003 4 BAILEY,President,,DEM,Under Votes,14
+Lane,0011 4 FOX HOLLOW,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0011 4 FOX HOLLOW,President,,DEM,John F. Kerry,276
+Lane,0011 4 FOX HOLLOW,President,,DEM,Dennis J. Kucinich,106
+Lane,0011 4 FOX HOLLOW,President,,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,President,,DEM,Under Votes,10
+Lane,0034 0 COBURG,President,,DEM,Lyndon H. Larouche Jr.,4
+Lane,0034 0 COBURG,President,,DEM,John F. Kerry,99
+Lane,0034 0 COBURG,President,,DEM,Dennis J. Kucinich,24
+Lane,0034 0 COBURG,President,,DEM,Over Votes,0
+Lane,0034 0 COBURG,President,,DEM,Under Votes,11
+Lane,0038 1 FLORENCE 1,President,,DEM,Lyndon H. Larouche Jr.,9
+Lane,0038 1 FLORENCE 1,President,,DEM,John F. Kerry,454
+Lane,0038 1 FLORENCE 1,President,,DEM,Dennis J. Kucinich,88
+Lane,0038 1 FLORENCE 1,President,,DEM,Over Votes,2
+Lane,0038 1 FLORENCE 1,President,,DEM,Under Votes,17
+Lane,0051 5 EUGENE 235,President,,DEM,Lyndon H. Larouche Jr.,9
+Lane,0051 5 EUGENE 235,President,,DEM,John F. Kerry,691
+Lane,0051 5 EUGENE 235,President,,DEM,Dennis J. Kucinich,322
+Lane,0051 5 EUGENE 235,President,,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,President,,DEM,Under Votes,27
+Lane,0016 5 GATEWAY,President,,DEM,Lyndon H. Larouche Jr.,3
+Lane,0016 5 GATEWAY,President,,DEM,John F. Kerry,192
+Lane,0016 5 GATEWAY,President,,DEM,Dennis J. Kucinich,23
+Lane,0016 5 GATEWAY,President,,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,President,,DEM,Under Votes,10
+Lane,0021 5 MARCOLA,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0021 5 MARCOLA,President,,DEM,John F. Kerry,196
+Lane,0021 5 MARCOLA,President,,DEM,Dennis J. Kucinich,49
+Lane,0021 5 MARCOLA,President,,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,President,,DEM,Under Votes,16
+Lane,0019 2 LOWELL,President,,DEM,Lyndon H. Larouche Jr.,13
+Lane,0019 2 LOWELL,President,,DEM,John F. Kerry,184
+Lane,0019 2 LOWELL,President,,DEM,Dennis J. Kucinich,50
+Lane,0019 2 LOWELL,President,,DEM,Over Votes,0
+Lane,0019 2 LOWELL,President,,DEM,Under Votes,24
+Lane,0017 7 LATHAM,President,,DEM,Lyndon H. Larouche Jr.,10
+Lane,0017 7 LATHAM,President,,DEM,John F. Kerry,235
+Lane,0017 7 LATHAM,President,,DEM,Dennis J. Kucinich,129
+Lane,0017 7 LATHAM,President,,DEM,Over Votes,0
+Lane,0017 7 LATHAM,President,,DEM,Under Votes,49
+Lane,0048 7 EUGENE 117,President,,DEM,Lyndon H. Larouche Jr.,2
+Lane,0048 7 EUGENE 117,President,,DEM,John F. Kerry,214
+Lane,0048 7 EUGENE 117,President,,DEM,Dennis J. Kucinich,130
+Lane,0048 7 EUGENE 117,President,,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,President,,DEM,Under Votes,8
+Lane,0006 8 COAST FORK,President,,DEM,Lyndon H. Larouche Jr.,12
+Lane,0006 8 COAST FORK,President,,DEM,John F. Kerry,238
+Lane,0006 8 COAST FORK,President,,DEM,Dennis J. Kucinich,64
+Lane,0006 8 COAST FORK,President,,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,President,,DEM,Under Votes,27
+Lane,0023 1 PLEASANT HILL 1,President,,DEM,Lyndon H. Larouche Jr.,17
+Lane,0023 1 PLEASANT HILL 1,President,,DEM,John F. Kerry,585
+Lane,0023 1 PLEASANT HILL 1,President,,DEM,Dennis J. Kucinich,132
+Lane,0023 1 PLEASANT HILL 1,President,,DEM,Over Votes,1
+Lane,0023 1 PLEASANT HILL 1,President,,DEM,Under Votes,129
+Lane,0050 3 EUGENE 223,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0050 3 EUGENE 223,President,,DEM,John F. Kerry,914
+Lane,0050 3 EUGENE 223,President,,DEM,Dennis J. Kucinich,293
+Lane,0050 3 EUGENE 223,President,,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,President,,DEM,Under Votes,32
+Lane,0009 0 ELMIRA,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0009 0 ELMIRA,President,,DEM,John F. Kerry,346
+Lane,0009 0 ELMIRA,President,,DEM,Dennis J. Kucinich,107
+Lane,0009 0 ELMIRA,President,,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,President,,DEM,Under Votes,29
+Lane,0025 6 RIVER ROAD,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0025 6 RIVER ROAD,President,,DEM,John F. Kerry,871
+Lane,0025 6 RIVER ROAD,President,,DEM,Dennis J. Kucinich,338
+Lane,0025 6 RIVER ROAD,President,,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,President,,DEM,Under Votes,38
+Lane,0022 7 MOSBY,President,,DEM,Lyndon H. Larouche Jr.,18
+Lane,0022 7 MOSBY,President,,DEM,John F. Kerry,470
+Lane,0022 7 MOSBY,President,,DEM,Dennis J. Kucinich,172
+Lane,0022 7 MOSBY,President,,DEM,Over Votes,1
+Lane,0022 7 MOSBY,President,,DEM,Under Votes,60
+Lane,0053 3 EUGENE 313,President,,DEM,Lyndon H. Larouche Jr.,7
+Lane,0053 3 EUGENE 313,President,,DEM,John F. Kerry,262
+Lane,0053 3 EUGENE 313,President,,DEM,Dennis J. Kucinich,115
+Lane,0053 3 EUGENE 313,President,,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,President,,DEM,Under Votes,6
+Lane,0020 3 MAPLETON,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0020 3 MAPLETON,President,,DEM,John F. Kerry,139
+Lane,0020 3 MAPLETON,President,,DEM,Dennis J. Kucinich,48
+Lane,0020 3 MAPLETON,President,,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,President,,DEM,Under Votes,11
+Lane,0001 1 ALVADORE,President,,DEM,Lyndon H. Larouche Jr.,10
+Lane,0001 1 ALVADORE,President,,DEM,John F. Kerry,248
+Lane,0001 1 ALVADORE,President,,DEM,Dennis J. Kucinich,37
+Lane,0001 1 ALVADORE,President,,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,President,,DEM,Under Votes,18
+Lane,0056 1 EUGENE 431,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0056 1 EUGENE 431,President,,DEM,John F. Kerry,189
+Lane,0056 1 EUGENE 431,President,,DEM,Dennis J. Kucinich,39
+Lane,0056 1 EUGENE 431,President,,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,President,,DEM,Under Votes,11
+Lane,0047 9 EUGENE 109,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0047 9 EUGENE 109,President,,DEM,John F. Kerry,13
+Lane,0047 9 EUGENE 109,President,,DEM,Dennis J. Kucinich,12
+Lane,0047 9 EUGENE 109,President,,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,President,,DEM,Under Votes,0
+Lane,0015 1 GROVEDALE,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0015 1 GROVEDALE,President,,DEM,John F. Kerry,217
+Lane,0015 1 GROVEDALE,President,,DEM,Dennis J. Kucinich,25
+Lane,0015 1 GROVEDALE,President,,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,President,,DEM,Under Votes,11
+Lane,0054 5 EUGENE 315,President,,DEM,Lyndon H. Larouche Jr.,3
+Lane,0054 5 EUGENE 315,President,,DEM,John F. Kerry,754
+Lane,0054 5 EUGENE 315,President,,DEM,Dennis J. Kucinich,334
+Lane,0054 5 EUGENE 315,President,,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,President,,DEM,Under Votes,28
+Lane,0043 1 EUGENE 101,President,,DEM,Lyndon H. Larouche Jr.,22
+Lane,0043 1 EUGENE 101,President,,DEM,John F. Kerry,988
+Lane,0043 1 EUGENE 101,President,,DEM,Dennis J. Kucinich,385
+Lane,0043 1 EUGENE 101,President,,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,President,,DEM,Under Votes,56
+Lane,0005 7 BLUE RIVER,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0005 7 BLUE RIVER,President,,DEM,John F. Kerry,282
+Lane,0005 7 BLUE RIVER,President,,DEM,Dennis J. Kucinich,63
+Lane,0005 7 BLUE RIVER,President,,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,President,,DEM,Under Votes,16
+Lane,0007 9 CAMAS,President,,DEM,Lyndon H. Larouche Jr.,4
+Lane,0007 9 CAMAS,President,,DEM,John F. Kerry,60
+Lane,0007 9 CAMAS,President,,DEM,Dennis J. Kucinich,27
+Lane,0007 9 CAMAS,President,,DEM,Over Votes,0
+Lane,0007 9 CAMAS,President,,DEM,Under Votes,4
+Lane,0036 0 CRESWELL,President,,DEM,Lyndon H. Larouche Jr.,2
+Lane,0036 0 CRESWELL,President,,DEM,John F. Kerry,227
+Lane,0036 0 CRESWELL,President,,DEM,Dennis J. Kucinich,41
+Lane,0036 0 CRESWELL,President,,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,President,,DEM,Under Votes,23
+Lane,0012 6 GARDEN WAY,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0012 6 GARDEN WAY,President,,DEM,John F. Kerry,61
+Lane,0012 6 GARDEN WAY,President,,DEM,Dennis J. Kucinich,13
+Lane,0012 6 GARDEN WAY,President,,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,President,,DEM,Under Votes,8
+Lane,0032 3 WILKINS,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0032 3 WILKINS,President,,DEM,John F. Kerry,262
+Lane,0032 3 WILKINS,President,,DEM,Dennis J. Kucinich,65
+Lane,0032 3 WILKINS,President,,DEM,Over Votes,0
+Lane,0032 3 WILKINS,President,,DEM,Under Votes,20
+Lane,0040 0 JUNCTION CITY,President,,DEM,Lyndon H. Larouche Jr.,9
+Lane,0040 0 JUNCTION CITY,President,,DEM,John F. Kerry,296
+Lane,0040 0 JUNCTION CITY,President,,DEM,Dennis J. Kucinich,38
+Lane,0040 0 JUNCTION CITY,President,,DEM,Over Votes,1
+Lane,0040 0 JUNCTION CITY,President,,DEM,Under Votes,15
+Lane,0057 3 EUGENE 433,President,,DEM,Lyndon H. Larouche Jr.,8
+Lane,0057 3 EUGENE 433,President,,DEM,John F. Kerry,473
+Lane,0057 3 EUGENE 433,President,,DEM,Dennis J. Kucinich,98
+Lane,0057 3 EUGENE 433,President,,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,President,,DEM,Under Votes,34
+Lane,0044 3 EUGENE 103,President,,DEM,Lyndon H. Larouche Jr.,9
+Lane,0044 3 EUGENE 103,President,,DEM,John F. Kerry,1128
+Lane,0044 3 EUGENE 103,President,,DEM,Dennis J. Kucinich,526
+Lane,0044 3 EUGENE 103,President,,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,President,,DEM,Under Votes,34
+Lane,0041 0 OAKRIDGE,President,,DEM,Lyndon H. Larouche Jr.,12
+Lane,0041 0 OAKRIDGE,President,,DEM,John F. Kerry,324
+Lane,0041 0 OAKRIDGE,President,,DEM,Dennis J. Kucinich,42
+Lane,0041 0 OAKRIDGE,President,,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,President,,DEM,Under Votes,52
+Lane,0033 5 MCKENZIE,U.S. Senate,,DEM,Ron Wyden,528
+Lane,0033 5 MCKENZIE,U.S. Senate,,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,U.S. Senate,,DEM,Under Votes,89
+Lane,0026 9 SALMON CREEK,U.S. Senate,,DEM,Ron Wyden,144
+Lane,0026 9 SALMON CREEK,U.S. Senate,,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,U.S. Senate,,DEM,Under Votes,20
+Lane,0013 7 GLENADA,U.S. Senate,,DEM,Ron Wyden,272
+Lane,0013 7 GLENADA,U.S. Senate,,DEM,Over Votes,0
+Lane,0013 7 GLENADA,U.S. Senate,,DEM,Under Votes,38
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,DEM,Ron Wyden,778
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,DEM,Under Votes,83
+Lane,0010 2 FERNRIDGE,U.S. Senate,,DEM,Ron Wyden,331
+Lane,0010 2 FERNRIDGE,U.S. Senate,,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,U.S. Senate,,DEM,Under Votes,57
+Lane,0002 3 ARMITAGE,U.S. Senate,,DEM,Ron Wyden,207
+Lane,0002 3 ARMITAGE,U.S. Senate,,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,U.S. Senate,,DEM,Under Votes,36
+Lane,0030 0 SIUSLAW,U.S. Senate,,DEM,Ron Wyden,445
+Lane,0030 0 SIUSLAW,U.S. Senate,,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,U.S. Senate,,DEM,Under Votes,41
+Lane,0052 7 EUGENE 237,U.S. Senate,,DEM,Ron Wyden,1049
+Lane,0052 7 EUGENE 237,U.S. Senate,,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,U.S. Senate,,DEM,Under Votes,123
+Lane,0004 5 BLACHLY,U.S. Senate,,DEM,Ron Wyden,233
+Lane,0004 5 BLACHLY,U.S. Senate,,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,U.S. Senate,,DEM,Under Votes,34
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,DEM,Ron Wyden,785
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,DEM,Over Votes,1
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,DEM,Under Votes,125
+Lane,0049 5 EUGENE 215,U.S. Senate,,DEM,Ron Wyden,1277
+Lane,0049 5 EUGENE 215,U.S. Senate,,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,U.S. Senate,,DEM,Under Votes,157
+Lane,0037 0 DUNES CITY,U.S. Senate,,DEM,Ron Wyden,188
+Lane,0037 0 DUNES CITY,U.S. Senate,,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,U.S. Senate,,DEM,Under Votes,24
+Lane,0042 0 VENETA,U.S. Senate,,DEM,Ron Wyden,229
+Lane,0042 0 VENETA,U.S. Senate,,DEM,Over Votes,0
+Lane,0042 0 VENETA,U.S. Senate,,DEM,Under Votes,28
+Lane,0031 2 WALTERVILLE,U.S. Senate,,DEM,Ron Wyden,393
+Lane,0031 2 WALTERVILLE,U.S. Senate,,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,U.S. Senate,,DEM,Under Votes,90
+Lane,0045 5 EUGENE 105,U.S. Senate,,DEM,Ron Wyden,172
+Lane,0045 5 EUGENE 105,U.S. Senate,,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,U.S. Senate,,DEM,Under Votes,30
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,DEM,Ron Wyden,130
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,DEM,Under Votes,31
+Lane,0055 7 EUGENE 317,U.S. Senate,,DEM,Ron Wyden,1126
+Lane,0055 7 EUGENE 317,U.S. Senate,,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,U.S. Senate,,DEM,Under Votes,174
+Lane,0039 2 FLORENCE 2,U.S. Senate,,DEM,Ron Wyden,541
+Lane,0039 2 FLORENCE 2,U.S. Senate,,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,U.S. Senate,,DEM,Under Votes,67
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,DEM,Ron Wyden,467
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,DEM,Under Votes,60
+Lane,0046 7 EUGENE 107,U.S. Senate,,DEM,Ron Wyden,192
+Lane,0046 7 EUGENE 107,U.S. Senate,,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,U.S. Senate,,DEM,Under Votes,41
+Lane,0008 2 CHESHIRE,U.S. Senate,,DEM,Ron Wyden,530
+Lane,0008 2 CHESHIRE,U.S. Senate,,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,U.S. Senate,,DEM,Under Votes,60
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,DEM,Ron Wyden,257
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,DEM,Under Votes,35
+Lane,0058 5 EUGENE 435,U.S. Senate,,DEM,Ron Wyden,695
+Lane,0058 5 EUGENE 435,U.S. Senate,,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,U.S. Senate,,DEM,Under Votes,87
+Lane,0014 0 GOSHEN,U.S. Senate,,DEM,Ron Wyden,438
+Lane,0014 0 GOSHEN,U.S. Senate,,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,U.S. Senate,,DEM,Under Votes,54
+Lane,0018 0 LORANE,U.S. Senate,,DEM,Ron Wyden,286
+Lane,0018 0 LORANE,U.S. Senate,,DEM,Over Votes,0
+Lane,0018 0 LORANE,U.S. Senate,,DEM,Under Votes,37
+Lane,0003 4 BAILEY,U.S. Senate,,DEM,Ron Wyden,300
+Lane,0003 4 BAILEY,U.S. Senate,,DEM,Over Votes,0
+Lane,0003 4 BAILEY,U.S. Senate,,DEM,Under Votes,36
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,DEM,Ron Wyden,364
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,DEM,Under Votes,36
+Lane,0034 0 COBURG,U.S. Senate,,DEM,Ron Wyden,121
+Lane,0034 0 COBURG,U.S. Senate,,DEM,Over Votes,0
+Lane,0034 0 COBURG,U.S. Senate,,DEM,Under Votes,20
+Lane,0038 1 FLORENCE 1,U.S. Senate,,DEM,Ron Wyden,531
+Lane,0038 1 FLORENCE 1,U.S. Senate,,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,U.S. Senate,,DEM,Under Votes,50
+Lane,0051 5 EUGENE 235,U.S. Senate,,DEM,Ron Wyden,943
+Lane,0051 5 EUGENE 235,U.S. Senate,,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,U.S. Senate,,DEM,Under Votes,114
+Lane,0016 5 GATEWAY,U.S. Senate,,DEM,Ron Wyden,213
+Lane,0016 5 GATEWAY,U.S. Senate,,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,U.S. Senate,,DEM,Under Votes,22
+Lane,0021 5 MARCOLA,U.S. Senate,,DEM,Ron Wyden,243
+Lane,0021 5 MARCOLA,U.S. Senate,,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,U.S. Senate,,DEM,Under Votes,28
+Lane,0019 2 LOWELL,U.S. Senate,,DEM,Ron Wyden,240
+Lane,0019 2 LOWELL,U.S. Senate,,DEM,Over Votes,0
+Lane,0019 2 LOWELL,U.S. Senate,,DEM,Under Votes,39
+Lane,0017 7 LATHAM,U.S. Senate,,DEM,Ron Wyden,367
+Lane,0017 7 LATHAM,U.S. Senate,,DEM,Over Votes,0
+Lane,0017 7 LATHAM,U.S. Senate,,DEM,Under Votes,66
+Lane,0048 7 EUGENE 117,U.S. Senate,,DEM,Ron Wyden,303
+Lane,0048 7 EUGENE 117,U.S. Senate,,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,U.S. Senate,,DEM,Under Votes,55
+Lane,0006 8 COAST FORK,U.S. Senate,,DEM,Ron Wyden,309
+Lane,0006 8 COAST FORK,U.S. Senate,,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,U.S. Senate,,DEM,Under Votes,41
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,DEM,Ron Wyden,728
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,DEM,Under Votes,153
+Lane,0050 3 EUGENE 223,U.S. Senate,,DEM,Ron Wyden,1130
+Lane,0050 3 EUGENE 223,U.S. Senate,,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,U.S. Senate,,DEM,Under Votes,131
+Lane,0009 0 ELMIRA,U.S. Senate,,DEM,Ron Wyden,452
+Lane,0009 0 ELMIRA,U.S. Senate,,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,U.S. Senate,,DEM,Under Votes,64
+Lane,0025 6 RIVER ROAD,U.S. Senate,,DEM,Ron Wyden,1112
+Lane,0025 6 RIVER ROAD,U.S. Senate,,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,U.S. Senate,,DEM,Under Votes,164
+Lane,0022 7 MOSBY,U.S. Senate,,DEM,Ron Wyden,626
+Lane,0022 7 MOSBY,U.S. Senate,,DEM,Over Votes,0
+Lane,0022 7 MOSBY,U.S. Senate,,DEM,Under Votes,122
+Lane,0053 3 EUGENE 313,U.S. Senate,,DEM,Ron Wyden,337
+Lane,0053 3 EUGENE 313,U.S. Senate,,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,U.S. Senate,,DEM,Under Votes,58
+Lane,0020 3 MAPLETON,U.S. Senate,,DEM,Ron Wyden,177
+Lane,0020 3 MAPLETON,U.S. Senate,,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,U.S. Senate,,DEM,Under Votes,31
+Lane,0001 1 ALVADORE,U.S. Senate,,DEM,Ron Wyden,279
+Lane,0001 1 ALVADORE,U.S. Senate,,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,U.S. Senate,,DEM,Under Votes,40
+Lane,0056 1 EUGENE 431,U.S. Senate,,DEM,Ron Wyden,220
+Lane,0056 1 EUGENE 431,U.S. Senate,,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,U.S. Senate,,DEM,Under Votes,25
+Lane,0047 9 EUGENE 109,U.S. Senate,,DEM,Ron Wyden,22
+Lane,0047 9 EUGENE 109,U.S. Senate,,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,U.S. Senate,,DEM,Under Votes,4
+Lane,0015 1 GROVEDALE,U.S. Senate,,DEM,Ron Wyden,234
+Lane,0015 1 GROVEDALE,U.S. Senate,,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,U.S. Senate,,DEM,Under Votes,20
+Lane,0054 5 EUGENE 315,U.S. Senate,,DEM,Ron Wyden,988
+Lane,0054 5 EUGENE 315,U.S. Senate,,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,U.S. Senate,,DEM,Under Votes,143
+Lane,0043 1 EUGENE 101,U.S. Senate,,DEM,Ron Wyden,1283
+Lane,0043 1 EUGENE 101,U.S. Senate,,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,U.S. Senate,,DEM,Under Votes,188
+Lane,0005 7 BLUE RIVER,U.S. Senate,,DEM,Ron Wyden,333
+Lane,0005 7 BLUE RIVER,U.S. Senate,,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,U.S. Senate,,DEM,Under Votes,32
+Lane,0007 9 CAMAS,U.S. Senate,,DEM,Ron Wyden,76
+Lane,0007 9 CAMAS,U.S. Senate,,DEM,Over Votes,0
+Lane,0007 9 CAMAS,U.S. Senate,,DEM,Under Votes,21
+Lane,0036 0 CRESWELL,U.S. Senate,,DEM,Ron Wyden,269
+Lane,0036 0 CRESWELL,U.S. Senate,,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,U.S. Senate,,DEM,Under Votes,30
+Lane,0012 6 GARDEN WAY,U.S. Senate,,DEM,Ron Wyden,80
+Lane,0012 6 GARDEN WAY,U.S. Senate,,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,U.S. Senate,,DEM,Under Votes,8
+Lane,0032 3 WILKINS,U.S. Senate,,DEM,Ron Wyden,316
+Lane,0032 3 WILKINS,U.S. Senate,,DEM,Over Votes,0
+Lane,0032 3 WILKINS,U.S. Senate,,DEM,Under Votes,40
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,DEM,Ron Wyden,325
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,DEM,Under Votes,37
+Lane,0057 3 EUGENE 433,U.S. Senate,,DEM,Ron Wyden,555
+Lane,0057 3 EUGENE 433,U.S. Senate,,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,U.S. Senate,,DEM,Under Votes,67
+Lane,0044 3 EUGENE 103,U.S. Senate,,DEM,Ron Wyden,1491
+Lane,0044 3 EUGENE 103,U.S. Senate,,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,U.S. Senate,,DEM,Under Votes,212
+Lane,0041 0 OAKRIDGE,U.S. Senate,,DEM,Ron Wyden,388
+Lane,0041 0 OAKRIDGE,U.S. Senate,,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,U.S. Senate,,DEM,Under Votes,54
+Lane,0078 6 SPRINGFIELD 206,President,,DEM,Lyndon H. Larouche Jr.,26
+Lane,0078 6 SPRINGFIELD 206,President,,DEM,John F. Kerry,642
+Lane,0078 6 SPRINGFIELD 206,President,,DEM,Dennis J. Kucinich,185
+Lane,0078 6 SPRINGFIELD 206,President,,DEM,Over Votes,2
+Lane,0078 6 SPRINGFIELD 206,President,,DEM,Under Votes,38
+Lane,0059 9 EUGENE 439,President,,DEM,Lyndon H. Larouche Jr.,15
+Lane,0059 9 EUGENE 439,President,,DEM,John F. Kerry,691
+Lane,0059 9 EUGENE 439,President,,DEM,Dennis J. Kucinich,106
+Lane,0059 9 EUGENE 439,President,,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,President,,DEM,Under Votes,41
+Lane,0069 5 EUGENE 715,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0069 5 EUGENE 715,President,,DEM,John F. Kerry,54
+Lane,0069 5 EUGENE 715,President,,DEM,Dennis J. Kucinich,18
+Lane,0069 5 EUGENE 715,President,,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,President,,DEM,Under Votes,1
+Lane,0062 1 EUGENE 511,President,,DEM,Lyndon H. Larouche Jr.,13
+Lane,0062 1 EUGENE 511,President,,DEM,John F. Kerry,849
+Lane,0062 1 EUGENE 511,President,,DEM,Dennis J. Kucinich,147
+Lane,0062 1 EUGENE 511,President,,DEM,Over Votes,0
+Lane,0062 1 EUGENE 511,President,,DEM,Under Votes,57
+Lane,0063 3 EUGENE 523,President,,DEM,Lyndon H. Larouche Jr.,12
+Lane,0063 3 EUGENE 523,President,,DEM,John F. Kerry,669
+Lane,0063 3 EUGENE 523,President,,DEM,Dennis J. Kucinich,81
+Lane,0063 3 EUGENE 523,President,,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,President,,DEM,Under Votes,42
+Lane,0068 3 EUGENE 713,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0068 3 EUGENE 713,President,,DEM,John F. Kerry,381
+Lane,0068 3 EUGENE 713,President,,DEM,Dennis J. Kucinich,54
+Lane,0068 3 EUGENE 713,President,,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,President,,DEM,Under Votes,23
+Lane,0075 7 EUGENE 807,President,,DEM,Lyndon H. Larouche Jr.,8
+Lane,0075 7 EUGENE 807,President,,DEM,John F. Kerry,950
+Lane,0075 7 EUGENE 807,President,,DEM,Dennis J. Kucinich,179
+Lane,0075 7 EUGENE 807,President,,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,President,,DEM,Under Votes,45
+Lane,0073 3 EUGENE 803,President,,DEM,Lyndon H. Larouche Jr.,3
+Lane,0073 3 EUGENE 803,President,,DEM,John F. Kerry,359
+Lane,0073 3 EUGENE 803,President,,DEM,Dennis J. Kucinich,119
+Lane,0073 3 EUGENE 803,President,,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,President,,DEM,Under Votes,9
+Lane,0064 3 EUGENE 613,President,,DEM,Lyndon H. Larouche Jr.,17
+Lane,0064 3 EUGENE 613,President,,DEM,John F. Kerry,689
+Lane,0064 3 EUGENE 613,President,,DEM,Dennis J. Kucinich,92
+Lane,0064 3 EUGENE 613,President,,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,President,,DEM,Under Votes,62
+Lane,0060 5 EUGENE 505,President,,DEM,Lyndon H. Larouche Jr.,2
+Lane,0060 5 EUGENE 505,President,,DEM,John F. Kerry,80
+Lane,0060 5 EUGENE 505,President,,DEM,Dennis J. Kucinich,14
+Lane,0060 5 EUGENE 505,President,,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,President,,DEM,Under Votes,1
+Lane,0074 5 EUGENE 805,President,,DEM,Lyndon H. Larouche Jr.,8
+Lane,0074 5 EUGENE 805,President,,DEM,John F. Kerry,290
+Lane,0074 5 EUGENE 805,President,,DEM,Dennis J. Kucinich,44
+Lane,0074 5 EUGENE 805,President,,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,President,,DEM,Under Votes,21
+Lane,0065 7 EUGENE 617,President,,DEM,Lyndon H. Larouche Jr.,26
+Lane,0065 7 EUGENE 617,President,,DEM,John F. Kerry,616
+Lane,0065 7 EUGENE 617,President,,DEM,Dennis J. Kucinich,72
+Lane,0065 7 EUGENE 617,President,,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,President,,DEM,Under Votes,44
+Lane,0067 1 EUGENE 711,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0067 1 EUGENE 711,President,,DEM,John F. Kerry,192
+Lane,0067 1 EUGENE 711,President,,DEM,Dennis J. Kucinich,58
+Lane,0067 1 EUGENE 711,President,,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,President,,DEM,Under Votes,7
+Lane,0066 3 EUGENE 623,President,,DEM,Lyndon H. Larouche Jr.,10
+Lane,0066 3 EUGENE 623,President,,DEM,John F. Kerry,450
+Lane,0066 3 EUGENE 623,President,,DEM,Dennis J. Kucinich,59
+Lane,0066 3 EUGENE 623,President,,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,President,,DEM,Under Votes,37
+Lane,0077 2 SPRINGFIELD 102,President,,DEM,Lyndon H. Larouche Jr.,16
+Lane,0077 2 SPRINGFIELD 102,President,,DEM,John F. Kerry,579
+Lane,0077 2 SPRINGFIELD 102,President,,DEM,Dennis J. Kucinich,80
+Lane,0077 2 SPRINGFIELD 102,President,,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,President,,DEM,Under Votes,41
+Lane,0083 8 SPRINGFIELD 608,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0083 8 SPRINGFIELD 608,President,,DEM,John F. Kerry,186
+Lane,0083 8 SPRINGFIELD 608,President,,DEM,Dennis J. Kucinich,26
+Lane,0083 8 SPRINGFIELD 608,President,,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,President,,DEM,Under Votes,13
+Lane,0071 9 EUGENE 719,President,,DEM,Lyndon H. Larouche Jr.,1
+Lane,0071 9 EUGENE 719,President,,DEM,John F. Kerry,55
+Lane,0071 9 EUGENE 719,President,,DEM,Dennis J. Kucinich,4
+Lane,0071 9 EUGENE 719,President,,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,President,,DEM,Under Votes,3
+Lane,0082 6 SPRINGFIELD 606,President,,DEM,Lyndon H. Larouche Jr.,22
+Lane,0082 6 SPRINGFIELD 606,President,,DEM,John F. Kerry,477
+Lane,0082 6 SPRINGFIELD 606,President,,DEM,Dennis J. Kucinich,69
+Lane,0082 6 SPRINGFIELD 606,President,,DEM,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,President,,DEM,Under Votes,41
+Lane,0072 3 EUGENE 723,President,,DEM,Lyndon H. Larouche Jr.,14
+Lane,0072 3 EUGENE 723,President,,DEM,John F. Kerry,725
+Lane,0072 3 EUGENE 723,President,,DEM,Dennis J. Kucinich,389
+Lane,0072 3 EUGENE 723,President,,DEM,Over Votes,1
+Lane,0072 3 EUGENE 723,President,,DEM,Under Votes,34
+Lane,0076 9 EUGENE 809,President,,DEM,Lyndon H. Larouche Jr.,6
+Lane,0076 9 EUGENE 809,President,,DEM,John F. Kerry,218
+Lane,0076 9 EUGENE 809,President,,DEM,Dennis J. Kucinich,53
+Lane,0076 9 EUGENE 809,President,,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,President,,DEM,Under Votes,17
+Lane,0081 4 SPRINGFIELD 504,President,,DEM,Lyndon H. Larouche Jr.,23
+Lane,0081 4 SPRINGFIELD 504,President,,DEM,John F. Kerry,534
+Lane,0081 4 SPRINGFIELD 504,President,,DEM,Dennis J. Kucinich,93
+Lane,0081 4 SPRINGFIELD 504,President,,DEM,Over Votes,1
+Lane,0081 4 SPRINGFIELD 504,President,,DEM,Under Votes,36
+Lane,0070 7 EUGENE 717,President,,DEM,Lyndon H. Larouche Jr.,0
+Lane,0070 7 EUGENE 717,President,,DEM,John F. Kerry,55
+Lane,0070 7 EUGENE 717,President,,DEM,Dennis J. Kucinich,14
+Lane,0070 7 EUGENE 717,President,,DEM,Over Votes,1
+Lane,0070 7 EUGENE 717,President,,DEM,Under Votes,1
+Lane,0080 2 SPRINGFIELD 402,President,,DEM,Lyndon H. Larouche Jr.,23
+Lane,0080 2 SPRINGFIELD 402,President,,DEM,John F. Kerry,590
+Lane,0080 2 SPRINGFIELD 402,President,,DEM,Dennis J. Kucinich,62
+Lane,0080 2 SPRINGFIELD 402,President,,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,President,,DEM,Under Votes,39
+Lane,0079 4 SPRINGFIELD 304,President,,DEM,Lyndon H. Larouche Jr.,21
+Lane,0079 4 SPRINGFIELD 304,President,,DEM,John F. Kerry,657
+Lane,0079 4 SPRINGFIELD 304,President,,DEM,Dennis J. Kucinich,132
+Lane,0079 4 SPRINGFIELD 304,President,,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,President,,DEM,Under Votes,37
+Lane,0061 7 EUGENE 507,President,,DEM,Lyndon H. Larouche Jr.,5
+Lane,0061 7 EUGENE 507,President,,DEM,John F. Kerry,379
+Lane,0061 7 EUGENE 507,President,,DEM,Dennis J. Kucinich,52
+Lane,0061 7 EUGENE 507,President,,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,President,,DEM,Under Votes,26
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,DEM,Ron Wyden,794
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,DEM,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,DEM,Under Votes,114
+Lane,0059 9 EUGENE 439,U.S. Senate,,DEM,Ron Wyden,768
+Lane,0059 9 EUGENE 439,U.S. Senate,,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,U.S. Senate,,DEM,Under Votes,97
+Lane,0069 5 EUGENE 715,U.S. Senate,,DEM,Ron Wyden,68
+Lane,0069 5 EUGENE 715,U.S. Senate,,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,U.S. Senate,,DEM,Under Votes,7
+Lane,0062 1 EUGENE 511,U.S. Senate,,DEM,Ron Wyden,943
+Lane,0062 1 EUGENE 511,U.S. Senate,,DEM,Over Votes,0
+Lane,0062 1 EUGENE 511,U.S. Senate,,DEM,Under Votes,135
+Lane,0063 3 EUGENE 523,U.S. Senate,,DEM,Ron Wyden,731
+Lane,0063 3 EUGENE 523,U.S. Senate,,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,U.S. Senate,,DEM,Under Votes,81
+Lane,0068 3 EUGENE 713,U.S. Senate,,DEM,Ron Wyden,430
+Lane,0068 3 EUGENE 713,U.S. Senate,,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,U.S. Senate,,DEM,Under Votes,39
+Lane,0075 7 EUGENE 807,U.S. Senate,,DEM,Ron Wyden,1053
+Lane,0075 7 EUGENE 807,U.S. Senate,,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,U.S. Senate,,DEM,Under Votes,142
+Lane,0073 3 EUGENE 803,U.S. Senate,,DEM,Ron Wyden,440
+Lane,0073 3 EUGENE 803,U.S. Senate,,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,U.S. Senate,,DEM,Under Votes,56
+Lane,0064 3 EUGENE 613,U.S. Senate,,DEM,Ron Wyden,753
+Lane,0064 3 EUGENE 613,U.S. Senate,,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,U.S. Senate,,DEM,Under Votes,124
+Lane,0060 5 EUGENE 505,U.S. Senate,,DEM,Ron Wyden,92
+Lane,0060 5 EUGENE 505,U.S. Senate,,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,U.S. Senate,,DEM,Under Votes,9
+Lane,0074 5 EUGENE 805,U.S. Senate,,DEM,Ron Wyden,321
+Lane,0074 5 EUGENE 805,U.S. Senate,,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,U.S. Senate,,DEM,Under Votes,44
+Lane,0065 7 EUGENE 617,U.S. Senate,,DEM,Ron Wyden,709
+Lane,0065 7 EUGENE 617,U.S. Senate,,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,U.S. Senate,,DEM,Under Votes,66
+Lane,0067 1 EUGENE 711,U.S. Senate,,DEM,Ron Wyden,231
+Lane,0067 1 EUGENE 711,U.S. Senate,,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,U.S. Senate,,DEM,Under Votes,35
+Lane,0066 3 EUGENE 623,U.S. Senate,,DEM,Ron Wyden,503
+Lane,0066 3 EUGENE 623,U.S. Senate,,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,U.S. Senate,,DEM,Under Votes,58
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,DEM,Ron Wyden,650
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,DEM,Under Votes,72
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,DEM,Ron Wyden,194
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,DEM,Under Votes,37
+Lane,0071 9 EUGENE 719,U.S. Senate,,DEM,Ron Wyden,56
+Lane,0071 9 EUGENE 719,U.S. Senate,,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,U.S. Senate,,DEM,Under Votes,7
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,DEM,Ron Wyden,540
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,DEM,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,DEM,Under Votes,86
+Lane,0072 3 EUGENE 723,U.S. Senate,,DEM,Ron Wyden,995
+Lane,0072 3 EUGENE 723,U.S. Senate,,DEM,Over Votes,0
+Lane,0072 3 EUGENE 723,U.S. Senate,,DEM,Under Votes,176
+Lane,0076 9 EUGENE 809,U.S. Senate,,DEM,Ron Wyden,261
+Lane,0076 9 EUGENE 809,U.S. Senate,,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,U.S. Senate,,DEM,Under Votes,41
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,DEM,Ron Wyden,643
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,DEM,Under Votes,69
+Lane,0070 7 EUGENE 717,U.S. Senate,,DEM,Ron Wyden,62
+Lane,0070 7 EUGENE 717,U.S. Senate,,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,U.S. Senate,,DEM,Under Votes,8
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,DEM,Ron Wyden,666
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,DEM,Under Votes,77
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,DEM,Ron Wyden,742
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,DEM,Under Votes,112
+Lane,0061 7 EUGENE 507,U.S. Senate,,DEM,Ron Wyden,414
+Lane,0061 7 EUGENE 507,U.S. Senate,,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,U.S. Senate,,DEM,Under Votes,55
+Lane,0033 5 MCKENZIE,U.S. House,4,DEM,Peter A. Defazio,567
+Lane,0033 5 MCKENZIE,U.S. House,4,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,U.S. House,4,DEM,Under Votes,53
+Lane,0026 9 SALMON CREEK,U.S. House,4,DEM,Peter A. Defazio,156
+Lane,0026 9 SALMON CREEK,U.S. House,4,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,U.S. House,4,DEM,Under Votes,9
+Lane,0013 7 GLENADA,U.S. House,4,DEM,Peter A. Defazio,281
+Lane,0013 7 GLENADA,U.S. House,4,DEM,Over Votes,0
+Lane,0013 7 GLENADA,U.S. House,4,DEM,Under Votes,29
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,DEM,Peter A. Defazio,800
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,DEM,Under Votes,65
+Lane,0010 2 FERNRIDGE,U.S. House,4,DEM,Peter A. Defazio,354
+Lane,0010 2 FERNRIDGE,U.S. House,4,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,U.S. House,4,DEM,Under Votes,33
+Lane,0002 3 ARMITAGE,U.S. House,4,DEM,Peter A. Defazio,217
+Lane,0002 3 ARMITAGE,U.S. House,4,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,U.S. House,4,DEM,Under Votes,26
+Lane,0030 0 SIUSLAW,U.S. House,4,DEM,Peter A. Defazio,461
+Lane,0030 0 SIUSLAW,U.S. House,4,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,U.S. House,4,DEM,Under Votes,27
+Lane,0052 7 EUGENE 237,U.S. House,4,DEM,Peter A. Defazio,1090
+Lane,0052 7 EUGENE 237,U.S. House,4,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,U.S. House,4,DEM,Under Votes,82
+Lane,0004 5 BLACHLY,U.S. House,4,DEM,Peter A. Defazio,238
+Lane,0004 5 BLACHLY,U.S. House,4,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,U.S. House,4,DEM,Under Votes,28
+Lane,0063 3 EUGENE 523,U.S. House,4,DEM,Peter A. Defazio,750
+Lane,0063 3 EUGENE 523,U.S. House,4,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,U.S. House,4,DEM,Under Votes,60
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,DEM,Peter A. Defazio,841
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,DEM,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,DEM,Under Votes,77
+Lane,0049 5 EUGENE 215,U.S. House,4,DEM,Peter A. Defazio,1352
+Lane,0049 5 EUGENE 215,U.S. House,4,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,U.S. House,4,DEM,Under Votes,85
+Lane,0037 0 DUNES CITY,U.S. House,4,DEM,Peter A. Defazio,197
+Lane,0037 0 DUNES CITY,U.S. House,4,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,U.S. House,4,DEM,Under Votes,15
+Lane,0042 0 VENETA,U.S. House,4,DEM,Peter A. Defazio,247
+Lane,0042 0 VENETA,U.S. House,4,DEM,Over Votes,0
+Lane,0042 0 VENETA,U.S. House,4,DEM,Under Votes,13
+Lane,0031 2 WALTERVILLE,U.S. House,4,DEM,Peter A. Defazio,442
+Lane,0031 2 WALTERVILLE,U.S. House,4,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,U.S. House,4,DEM,Under Votes,43
+Lane,0045 5 EUGENE 105,U.S. House,4,DEM,Peter A. Defazio,195
+Lane,0045 5 EUGENE 105,U.S. House,4,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,U.S. House,4,DEM,Under Votes,10
+Lane,0062 1 EUGENE 511,U.S. House,4,DEM,Peter A. Defazio,984
+Lane,0062 1 EUGENE 511,U.S. House,4,DEM,Over Votes,0
+Lane,0062 1 EUGENE 511,U.S. House,4,DEM,Under Votes,96
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,DEM,Peter A. Defazio,144
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,DEM,Under Votes,17
+Lane,0055 7 EUGENE 317,U.S. House,4,DEM,Peter A. Defazio,1211
+Lane,0055 7 EUGENE 317,U.S. House,4,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,U.S. House,4,DEM,Under Votes,94
+Lane,0039 2 FLORENCE 2,U.S. House,4,DEM,Peter A. Defazio,566
+Lane,0039 2 FLORENCE 2,U.S. House,4,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,U.S. House,4,DEM,Under Votes,42
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,DEM,Peter A. Defazio,489
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,DEM,Under Votes,35
+Lane,0060 5 EUGENE 505,U.S. House,4,DEM,Peter A. Defazio,98
+Lane,0060 5 EUGENE 505,U.S. House,4,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,U.S. House,4,DEM,Under Votes,4
+Lane,0046 7 EUGENE 107,U.S. House,4,DEM,Peter A. Defazio,218
+Lane,0046 7 EUGENE 107,U.S. House,4,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,U.S. House,4,DEM,Under Votes,15
+Lane,0008 2 CHESHIRE,U.S. House,4,DEM,Peter A. Defazio,549
+Lane,0008 2 CHESHIRE,U.S. House,4,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,U.S. House,4,DEM,Under Votes,42
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,DEM,Peter A. Defazio,274
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,DEM,Under Votes,17
+Lane,0058 5 EUGENE 435,U.S. House,4,DEM,Peter A. Defazio,720
+Lane,0058 5 EUGENE 435,U.S. House,4,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,U.S. House,4,DEM,Under Votes,61
+Lane,0014 0 GOSHEN,U.S. House,4,DEM,Peter A. Defazio,462
+Lane,0014 0 GOSHEN,U.S. House,4,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,U.S. House,4,DEM,Under Votes,36
+Lane,0018 0 LORANE,U.S. House,4,DEM,Peter A. Defazio,307
+Lane,0018 0 LORANE,U.S. House,4,DEM,Over Votes,0
+Lane,0018 0 LORANE,U.S. House,4,DEM,Under Votes,18
+Lane,0003 4 BAILEY,U.S. House,4,DEM,Peter A. Defazio,312
+Lane,0003 4 BAILEY,U.S. House,4,DEM,Over Votes,0
+Lane,0003 4 BAILEY,U.S. House,4,DEM,Under Votes,24
+Lane,0011 4 FOX HOLLOW,U.S. House,4,DEM,Peter A. Defazio,386
+Lane,0011 4 FOX HOLLOW,U.S. House,4,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,U.S. House,4,DEM,Under Votes,18
+Lane,0059 9 EUGENE 439,U.S. House,4,DEM,Peter A. Defazio,807
+Lane,0059 9 EUGENE 439,U.S. House,4,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,U.S. House,4,DEM,Under Votes,57
+Lane,0061 7 EUGENE 507,U.S. House,4,DEM,Peter A. Defazio,431
+Lane,0061 7 EUGENE 507,U.S. House,4,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,U.S. House,4,DEM,Under Votes,39
+Lane,0034 0 COBURG,U.S. House,4,DEM,Peter A. Defazio,127
+Lane,0034 0 COBURG,U.S. House,4,DEM,Over Votes,0
+Lane,0034 0 COBURG,U.S. House,4,DEM,Under Votes,13
+Lane,0038 1 FLORENCE 1,U.S. House,4,DEM,Peter A. Defazio,540
+Lane,0038 1 FLORENCE 1,U.S. House,4,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,U.S. House,4,DEM,Under Votes,39
+Lane,0051 5 EUGENE 235,U.S. House,4,DEM,Peter A. Defazio,1003
+Lane,0051 5 EUGENE 235,U.S. House,4,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,U.S. House,4,DEM,Under Votes,53
+Lane,0016 5 GATEWAY,U.S. House,4,DEM,Peter A. Defazio,222
+Lane,0016 5 GATEWAY,U.S. House,4,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,U.S. House,4,DEM,Under Votes,14
+Lane,0021 5 MARCOLA,U.S. House,4,DEM,Peter A. Defazio,261
+Lane,0021 5 MARCOLA,U.S. House,4,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,U.S. House,4,DEM,Under Votes,11
+Lane,0019 2 LOWELL,U.S. House,4,DEM,Peter A. Defazio,250
+Lane,0019 2 LOWELL,U.S. House,4,DEM,Over Votes,0
+Lane,0019 2 LOWELL,U.S. House,4,DEM,Under Votes,29
+Lane,0017 7 LATHAM,U.S. House,4,DEM,Peter A. Defazio,384
+Lane,0017 7 LATHAM,U.S. House,4,DEM,Over Votes,0
+Lane,0017 7 LATHAM,U.S. House,4,DEM,Under Votes,50
+Lane,0048 7 EUGENE 117,U.S. House,4,DEM,Peter A. Defazio,336
+Lane,0048 7 EUGENE 117,U.S. House,4,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,U.S. House,4,DEM,Under Votes,24
+Lane,0006 8 COAST FORK,U.S. House,4,DEM,Peter A. Defazio,323
+Lane,0006 8 COAST FORK,U.S. House,4,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,U.S. House,4,DEM,Under Votes,27
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,DEM,Peter A. Defazio,778
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,DEM,Under Votes,103
+Lane,0050 3 EUGENE 223,U.S. House,4,DEM,Peter A. Defazio,1186
+Lane,0050 3 EUGENE 223,U.S. House,4,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,U.S. House,4,DEM,Under Votes,76
+Lane,0009 0 ELMIRA,U.S. House,4,DEM,Peter A. Defazio,479
+Lane,0009 0 ELMIRA,U.S. House,4,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,U.S. House,4,DEM,Under Votes,36
+Lane,0025 6 RIVER ROAD,U.S. House,4,DEM,Peter A. Defazio,1212
+Lane,0025 6 RIVER ROAD,U.S. House,4,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,U.S. House,4,DEM,Under Votes,68
+Lane,0022 7 MOSBY,U.S. House,4,DEM,Peter A. Defazio,681
+Lane,0022 7 MOSBY,U.S. House,4,DEM,Over Votes,0
+Lane,0022 7 MOSBY,U.S. House,4,DEM,Under Votes,72
+Lane,0053 3 EUGENE 313,U.S. House,4,DEM,Peter A. Defazio,353
+Lane,0053 3 EUGENE 313,U.S. House,4,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,U.S. House,4,DEM,Under Votes,42
+Lane,0020 3 MAPLETON,U.S. House,4,DEM,Peter A. Defazio,186
+Lane,0020 3 MAPLETON,U.S. House,4,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,U.S. House,4,DEM,Under Votes,21
+Lane,0001 1 ALVADORE,U.S. House,4,DEM,Peter A. Defazio,294
+Lane,0001 1 ALVADORE,U.S. House,4,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,U.S. House,4,DEM,Under Votes,25
+Lane,0056 1 EUGENE 431,U.S. House,4,DEM,Peter A. Defazio,223
+Lane,0056 1 EUGENE 431,U.S. House,4,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,U.S. House,4,DEM,Under Votes,22
+Lane,0047 9 EUGENE 109,U.S. House,4,DEM,Peter A. Defazio,23
+Lane,0047 9 EUGENE 109,U.S. House,4,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,U.S. House,4,DEM,Under Votes,3
+Lane,0015 1 GROVEDALE,U.S. House,4,DEM,Peter A. Defazio,249
+Lane,0015 1 GROVEDALE,U.S. House,4,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,U.S. House,4,DEM,Under Votes,8
+Lane,0054 5 EUGENE 315,U.S. House,4,DEM,Peter A. Defazio,1037
+Lane,0054 5 EUGENE 315,U.S. House,4,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,U.S. House,4,DEM,Under Votes,98
+Lane,0043 1 EUGENE 101,U.S. House,4,DEM,Peter A. Defazio,1367
+Lane,0043 1 EUGENE 101,U.S. House,4,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,U.S. House,4,DEM,Under Votes,105
+Lane,0005 7 BLUE RIVER,U.S. House,4,DEM,Peter A. Defazio,348
+Lane,0005 7 BLUE RIVER,U.S. House,4,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,U.S. House,4,DEM,Under Votes,19
+Lane,0007 9 CAMAS,U.S. House,4,DEM,Peter A. Defazio,84
+Lane,0007 9 CAMAS,U.S. House,4,DEM,Over Votes,0
+Lane,0007 9 CAMAS,U.S. House,4,DEM,Under Votes,13
+Lane,0036 0 CRESWELL,U.S. House,4,DEM,Peter A. Defazio,282
+Lane,0036 0 CRESWELL,U.S. House,4,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,U.S. House,4,DEM,Under Votes,18
+Lane,0012 6 GARDEN WAY,U.S. House,4,DEM,Peter A. Defazio,87
+Lane,0012 6 GARDEN WAY,U.S. House,4,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,U.S. House,4,DEM,Under Votes,1
+Lane,0032 3 WILKINS,U.S. House,4,DEM,Peter A. Defazio,328
+Lane,0032 3 WILKINS,U.S. House,4,DEM,Over Votes,0
+Lane,0032 3 WILKINS,U.S. House,4,DEM,Under Votes,28
+Lane,0040 0 JUNCTION CITY,U.S. House,4,DEM,Peter A. Defazio,356
+Lane,0040 0 JUNCTION CITY,U.S. House,4,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,U.S. House,4,DEM,Under Votes,9
+Lane,0057 3 EUGENE 433,U.S. House,4,DEM,Peter A. Defazio,584
+Lane,0057 3 EUGENE 433,U.S. House,4,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,U.S. House,4,DEM,Under Votes,36
+Lane,0044 3 EUGENE 103,U.S. House,4,DEM,Peter A. Defazio,1613
+Lane,0044 3 EUGENE 103,U.S. House,4,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,U.S. House,4,DEM,Under Votes,94
+Lane,0041 0 OAKRIDGE,U.S. House,4,DEM,Peter A. Defazio,403
+Lane,0041 0 OAKRIDGE,U.S. House,4,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,U.S. House,4,DEM,Under Votes,40
+Lane,0033 5 MCKENZIE,Secretary of State,,DEM,Bill Bradbury,478
+Lane,0033 5 MCKENZIE,Secretary of State,,DEM,Paul Damian Wells,80
+Lane,0033 5 MCKENZIE,Secretary of State,,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,Secretary of State,,DEM,Under Votes,65
+Lane,0026 9 SALMON CREEK,Secretary of State,,DEM,Bill Bradbury,131
+Lane,0026 9 SALMON CREEK,Secretary of State,,DEM,Paul Damian Wells,15
+Lane,0026 9 SALMON CREEK,Secretary of State,,DEM,Over Votes,1
+Lane,0026 9 SALMON CREEK,Secretary of State,,DEM,Under Votes,18
+Lane,0013 7 GLENADA,Secretary of State,,DEM,Bill Bradbury,236
+Lane,0013 7 GLENADA,Secretary of State,,DEM,Paul Damian Wells,43
+Lane,0013 7 GLENADA,Secretary of State,,DEM,Over Votes,0
+Lane,0013 7 GLENADA,Secretary of State,,DEM,Under Votes,32
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,DEM,Bill Bradbury,696
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,DEM,Paul Damian Wells,91
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,DEM,Under Votes,81
+Lane,0010 2 FERNRIDGE,Secretary of State,,DEM,Bill Bradbury,301
+Lane,0010 2 FERNRIDGE,Secretary of State,,DEM,Paul Damian Wells,53
+Lane,0010 2 FERNRIDGE,Secretary of State,,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,Secretary of State,,DEM,Under Votes,33
+Lane,0002 3 ARMITAGE,Secretary of State,,DEM,Bill Bradbury,183
+Lane,0002 3 ARMITAGE,Secretary of State,,DEM,Paul Damian Wells,29
+Lane,0002 3 ARMITAGE,Secretary of State,,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,Secretary of State,,DEM,Under Votes,31
+Lane,0030 0 SIUSLAW,Secretary of State,,DEM,Bill Bradbury,392
+Lane,0030 0 SIUSLAW,Secretary of State,,DEM,Paul Damian Wells,65
+Lane,0030 0 SIUSLAW,Secretary of State,,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,Secretary of State,,DEM,Under Votes,31
+Lane,0052 7 EUGENE 237,Secretary of State,,DEM,Bill Bradbury,1031
+Lane,0052 7 EUGENE 237,Secretary of State,,DEM,Paul Damian Wells,37
+Lane,0052 7 EUGENE 237,Secretary of State,,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,Secretary of State,,DEM,Under Votes,105
+Lane,0004 5 BLACHLY,Secretary of State,,DEM,Bill Bradbury,219
+Lane,0004 5 BLACHLY,Secretary of State,,DEM,Paul Damian Wells,23
+Lane,0004 5 BLACHLY,Secretary of State,,DEM,Over Votes,1
+Lane,0004 5 BLACHLY,Secretary of State,,DEM,Under Votes,24
+Lane,0063 3 EUGENE 523,Secretary of State,,DEM,Bill Bradbury,674
+Lane,0063 3 EUGENE 523,Secretary of State,,DEM,Paul Damian Wells,43
+Lane,0063 3 EUGENE 523,Secretary of State,,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,Secretary of State,,DEM,Under Votes,95
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,DEM,Bill Bradbury,701
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,DEM,Paul Damian Wells,106
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,DEM,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,DEM,Under Votes,109
+Lane,0049 5 EUGENE 215,Secretary of State,,DEM,Bill Bradbury,1234
+Lane,0049 5 EUGENE 215,Secretary of State,,DEM,Paul Damian Wells,57
+Lane,0049 5 EUGENE 215,Secretary of State,,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,Secretary of State,,DEM,Under Votes,145
+Lane,0037 0 DUNES CITY,Secretary of State,,DEM,Bill Bradbury,160
+Lane,0037 0 DUNES CITY,Secretary of State,,DEM,Paul Damian Wells,25
+Lane,0037 0 DUNES CITY,Secretary of State,,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,Secretary of State,,DEM,Under Votes,27
+Lane,0042 0 VENETA,Secretary of State,,DEM,Bill Bradbury,192
+Lane,0042 0 VENETA,Secretary of State,,DEM,Paul Damian Wells,47
+Lane,0042 0 VENETA,Secretary of State,,DEM,Over Votes,0
+Lane,0042 0 VENETA,Secretary of State,,DEM,Under Votes,21
+Lane,0031 2 WALTERVILLE,Secretary of State,,DEM,Bill Bradbury,375
+Lane,0031 2 WALTERVILLE,Secretary of State,,DEM,Paul Damian Wells,65
+Lane,0031 2 WALTERVILLE,Secretary of State,,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,Secretary of State,,DEM,Under Votes,44
+Lane,0045 5 EUGENE 105,Secretary of State,,DEM,Bill Bradbury,174
+Lane,0045 5 EUGENE 105,Secretary of State,,DEM,Paul Damian Wells,15
+Lane,0045 5 EUGENE 105,Secretary of State,,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,Secretary of State,,DEM,Under Votes,16
+Lane,0062 1 EUGENE 511,Secretary of State,,DEM,Bill Bradbury,882
+Lane,0062 1 EUGENE 511,Secretary of State,,DEM,Paul Damian Wells,71
+Lane,0062 1 EUGENE 511,Secretary of State,,DEM,Over Votes,1
+Lane,0062 1 EUGENE 511,Secretary of State,,DEM,Under Votes,124
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,DEM,Bill Bradbury,106
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,DEM,Paul Damian Wells,19
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,DEM,Under Votes,36
+Lane,0055 7 EUGENE 317,Secretary of State,,DEM,Bill Bradbury,1151
+Lane,0055 7 EUGENE 317,Secretary of State,,DEM,Paul Damian Wells,35
+Lane,0055 7 EUGENE 317,Secretary of State,,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,Secretary of State,,DEM,Under Votes,119
+Lane,0039 2 FLORENCE 2,Secretary of State,,DEM,Bill Bradbury,479
+Lane,0039 2 FLORENCE 2,Secretary of State,,DEM,Paul Damian Wells,71
+Lane,0039 2 FLORENCE 2,Secretary of State,,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,Secretary of State,,DEM,Under Votes,58
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,DEM,Bill Bradbury,430
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,DEM,Paul Damian Wells,48
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,DEM,Under Votes,50
+Lane,0060 5 EUGENE 505,Secretary of State,,DEM,Bill Bradbury,83
+Lane,0060 5 EUGENE 505,Secretary of State,,DEM,Paul Damian Wells,11
+Lane,0060 5 EUGENE 505,Secretary of State,,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,Secretary of State,,DEM,Under Votes,10
+Lane,0046 7 EUGENE 107,Secretary of State,,DEM,Bill Bradbury,190
+Lane,0046 7 EUGENE 107,Secretary of State,,DEM,Paul Damian Wells,18
+Lane,0046 7 EUGENE 107,Secretary of State,,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,Secretary of State,,DEM,Under Votes,25
+Lane,0008 2 CHESHIRE,Secretary of State,,DEM,Bill Bradbury,486
+Lane,0008 2 CHESHIRE,Secretary of State,,DEM,Paul Damian Wells,59
+Lane,0008 2 CHESHIRE,Secretary of State,,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,Secretary of State,,DEM,Under Votes,47
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,DEM,Bill Bradbury,229
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,DEM,Paul Damian Wells,36
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,DEM,Under Votes,30
+Lane,0058 5 EUGENE 435,Secretary of State,,DEM,Bill Bradbury,659
+Lane,0058 5 EUGENE 435,Secretary of State,,DEM,Paul Damian Wells,52
+Lane,0058 5 EUGENE 435,Secretary of State,,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,Secretary of State,,DEM,Under Votes,69
+Lane,0014 0 GOSHEN,Secretary of State,,DEM,Bill Bradbury,404
+Lane,0014 0 GOSHEN,Secretary of State,,DEM,Paul Damian Wells,43
+Lane,0014 0 GOSHEN,Secretary of State,,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,Secretary of State,,DEM,Under Votes,50
+Lane,0018 0 LORANE,Secretary of State,,DEM,Bill Bradbury,255
+Lane,0018 0 LORANE,Secretary of State,,DEM,Paul Damian Wells,45
+Lane,0018 0 LORANE,Secretary of State,,DEM,Over Votes,0
+Lane,0018 0 LORANE,Secretary of State,,DEM,Under Votes,25
+Lane,0003 4 BAILEY,Secretary of State,,DEM,Bill Bradbury,285
+Lane,0003 4 BAILEY,Secretary of State,,DEM,Paul Damian Wells,21
+Lane,0003 4 BAILEY,Secretary of State,,DEM,Over Votes,0
+Lane,0003 4 BAILEY,Secretary of State,,DEM,Under Votes,30
+Lane,0011 4 FOX HOLLOW,Secretary of State,,DEM,Bill Bradbury,338
+Lane,0011 4 FOX HOLLOW,Secretary of State,,DEM,Paul Damian Wells,29
+Lane,0011 4 FOX HOLLOW,Secretary of State,,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,Secretary of State,,DEM,Under Votes,34
+Lane,0059 9 EUGENE 439,Secretary of State,,DEM,Bill Bradbury,734
+Lane,0059 9 EUGENE 439,Secretary of State,,DEM,Paul Damian Wells,48
+Lane,0059 9 EUGENE 439,Secretary of State,,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,Secretary of State,,DEM,Under Votes,82
+Lane,0061 7 EUGENE 507,Secretary of State,,DEM,Bill Bradbury,388
+Lane,0061 7 EUGENE 507,Secretary of State,,DEM,Paul Damian Wells,29
+Lane,0061 7 EUGENE 507,Secretary of State,,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,Secretary of State,,DEM,Under Votes,54
+Lane,0034 0 COBURG,Secretary of State,,DEM,Bill Bradbury,110
+Lane,0034 0 COBURG,Secretary of State,,DEM,Paul Damian Wells,16
+Lane,0034 0 COBURG,Secretary of State,,DEM,Over Votes,0
+Lane,0034 0 COBURG,Secretary of State,,DEM,Under Votes,14
+Lane,0038 1 FLORENCE 1,Secretary of State,,DEM,Bill Bradbury,471
+Lane,0038 1 FLORENCE 1,Secretary of State,,DEM,Paul Damian Wells,63
+Lane,0038 1 FLORENCE 1,Secretary of State,,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,Secretary of State,,DEM,Under Votes,47
+Lane,0051 5 EUGENE 235,Secretary of State,,DEM,Bill Bradbury,924
+Lane,0051 5 EUGENE 235,Secretary of State,,DEM,Paul Damian Wells,46
+Lane,0051 5 EUGENE 235,Secretary of State,,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,Secretary of State,,DEM,Under Votes,87
+Lane,0016 5 GATEWAY,Secretary of State,,DEM,Bill Bradbury,182
+Lane,0016 5 GATEWAY,Secretary of State,,DEM,Paul Damian Wells,32
+Lane,0016 5 GATEWAY,Secretary of State,,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,Secretary of State,,DEM,Under Votes,22
+Lane,0021 5 MARCOLA,Secretary of State,,DEM,Bill Bradbury,210
+Lane,0021 5 MARCOLA,Secretary of State,,DEM,Paul Damian Wells,37
+Lane,0021 5 MARCOLA,Secretary of State,,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,Secretary of State,,DEM,Under Votes,25
+Lane,0019 2 LOWELL,Secretary of State,,DEM,Bill Bradbury,212
+Lane,0019 2 LOWELL,Secretary of State,,DEM,Paul Damian Wells,34
+Lane,0019 2 LOWELL,Secretary of State,,DEM,Over Votes,0
+Lane,0019 2 LOWELL,Secretary of State,,DEM,Under Votes,33
+Lane,0017 7 LATHAM,Secretary of State,,DEM,Bill Bradbury,314
+Lane,0017 7 LATHAM,Secretary of State,,DEM,Paul Damian Wells,54
+Lane,0017 7 LATHAM,Secretary of State,,DEM,Over Votes,0
+Lane,0017 7 LATHAM,Secretary of State,,DEM,Under Votes,68
+Lane,0048 7 EUGENE 117,Secretary of State,,DEM,Bill Bradbury,305
+Lane,0048 7 EUGENE 117,Secretary of State,,DEM,Paul Damian Wells,21
+Lane,0048 7 EUGENE 117,Secretary of State,,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,Secretary of State,,DEM,Under Votes,34
+Lane,0006 8 COAST FORK,Secretary of State,,DEM,Bill Bradbury,255
+Lane,0006 8 COAST FORK,Secretary of State,,DEM,Paul Damian Wells,61
+Lane,0006 8 COAST FORK,Secretary of State,,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,Secretary of State,,DEM,Under Votes,34
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,DEM,Bill Bradbury,628
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,DEM,Paul Damian Wells,82
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,DEM,Under Votes,173
+Lane,0050 3 EUGENE 223,Secretary of State,,DEM,Bill Bradbury,1106
+Lane,0050 3 EUGENE 223,Secretary of State,,DEM,Paul Damian Wells,47
+Lane,0050 3 EUGENE 223,Secretary of State,,DEM,Over Votes,2
+Lane,0050 3 EUGENE 223,Secretary of State,,DEM,Under Votes,111
+Lane,0009 0 ELMIRA,Secretary of State,,DEM,Bill Bradbury,386
+Lane,0009 0 ELMIRA,Secretary of State,,DEM,Paul Damian Wells,73
+Lane,0009 0 ELMIRA,Secretary of State,,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,Secretary of State,,DEM,Under Votes,57
+Lane,0025 6 RIVER ROAD,Secretary of State,,DEM,Bill Bradbury,1062
+Lane,0025 6 RIVER ROAD,Secretary of State,,DEM,Paul Damian Wells,94
+Lane,0025 6 RIVER ROAD,Secretary of State,,DEM,Over Votes,1
+Lane,0025 6 RIVER ROAD,Secretary of State,,DEM,Under Votes,126
+Lane,0022 7 MOSBY,Secretary of State,,DEM,Bill Bradbury,529
+Lane,0022 7 MOSBY,Secretary of State,,DEM,Paul Damian Wells,114
+Lane,0022 7 MOSBY,Secretary of State,,DEM,Over Votes,1
+Lane,0022 7 MOSBY,Secretary of State,,DEM,Under Votes,108
+Lane,0053 3 EUGENE 313,Secretary of State,,DEM,Bill Bradbury,311
+Lane,0053 3 EUGENE 313,Secretary of State,,DEM,Paul Damian Wells,28
+Lane,0053 3 EUGENE 313,Secretary of State,,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,Secretary of State,,DEM,Under Votes,57
+Lane,0020 3 MAPLETON,Secretary of State,,DEM,Bill Bradbury,162
+Lane,0020 3 MAPLETON,Secretary of State,,DEM,Paul Damian Wells,31
+Lane,0020 3 MAPLETON,Secretary of State,,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,Secretary of State,,DEM,Under Votes,14
+Lane,0001 1 ALVADORE,Secretary of State,,DEM,Bill Bradbury,236
+Lane,0001 1 ALVADORE,Secretary of State,,DEM,Paul Damian Wells,43
+Lane,0001 1 ALVADORE,Secretary of State,,DEM,Over Votes,1
+Lane,0001 1 ALVADORE,Secretary of State,,DEM,Under Votes,38
+Lane,0056 1 EUGENE 431,Secretary of State,,DEM,Bill Bradbury,216
+Lane,0056 1 EUGENE 431,Secretary of State,,DEM,Paul Damian Wells,13
+Lane,0056 1 EUGENE 431,Secretary of State,,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,Secretary of State,,DEM,Under Votes,17
+Lane,0047 9 EUGENE 109,Secretary of State,,DEM,Bill Bradbury,17
+Lane,0047 9 EUGENE 109,Secretary of State,,DEM,Paul Damian Wells,2
+Lane,0047 9 EUGENE 109,Secretary of State,,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,Secretary of State,,DEM,Under Votes,7
+Lane,0015 1 GROVEDALE,Secretary of State,,DEM,Bill Bradbury,220
+Lane,0015 1 GROVEDALE,Secretary of State,,DEM,Paul Damian Wells,18
+Lane,0015 1 GROVEDALE,Secretary of State,,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,Secretary of State,,DEM,Under Votes,18
+Lane,0054 5 EUGENE 315,Secretary of State,,DEM,Bill Bradbury,990
+Lane,0054 5 EUGENE 315,Secretary of State,,DEM,Paul Damian Wells,38
+Lane,0054 5 EUGENE 315,Secretary of State,,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,Secretary of State,,DEM,Under Votes,109
+Lane,0043 1 EUGENE 101,Secretary of State,,DEM,Bill Bradbury,1239
+Lane,0043 1 EUGENE 101,Secretary of State,,DEM,Paul Damian Wells,92
+Lane,0043 1 EUGENE 101,Secretary of State,,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,Secretary of State,,DEM,Under Votes,146
+Lane,0005 7 BLUE RIVER,Secretary of State,,DEM,Bill Bradbury,308
+Lane,0005 7 BLUE RIVER,Secretary of State,,DEM,Paul Damian Wells,24
+Lane,0005 7 BLUE RIVER,Secretary of State,,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,Secretary of State,,DEM,Under Votes,34
+Lane,0007 9 CAMAS,Secretary of State,,DEM,Bill Bradbury,75
+Lane,0007 9 CAMAS,Secretary of State,,DEM,Paul Damian Wells,10
+Lane,0007 9 CAMAS,Secretary of State,,DEM,Over Votes,0
+Lane,0007 9 CAMAS,Secretary of State,,DEM,Under Votes,12
+Lane,0036 0 CRESWELL,Secretary of State,,DEM,Bill Bradbury,233
+Lane,0036 0 CRESWELL,Secretary of State,,DEM,Paul Damian Wells,42
+Lane,0036 0 CRESWELL,Secretary of State,,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,Secretary of State,,DEM,Under Votes,27
+Lane,0012 6 GARDEN WAY,Secretary of State,,DEM,Bill Bradbury,64
+Lane,0012 6 GARDEN WAY,Secretary of State,,DEM,Paul Damian Wells,13
+Lane,0012 6 GARDEN WAY,Secretary of State,,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,Secretary of State,,DEM,Under Votes,11
+Lane,0032 3 WILKINS,Secretary of State,,DEM,Bill Bradbury,288
+Lane,0032 3 WILKINS,Secretary of State,,DEM,Paul Damian Wells,41
+Lane,0032 3 WILKINS,Secretary of State,,DEM,Over Votes,0
+Lane,0032 3 WILKINS,Secretary of State,,DEM,Under Votes,28
+Lane,0040 0 JUNCTION CITY,Secretary of State,,DEM,Bill Bradbury,280
+Lane,0040 0 JUNCTION CITY,Secretary of State,,DEM,Paul Damian Wells,45
+Lane,0040 0 JUNCTION CITY,Secretary of State,,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,Secretary of State,,DEM,Under Votes,39
+Lane,0057 3 EUGENE 433,Secretary of State,,DEM,Bill Bradbury,528
+Lane,0057 3 EUGENE 433,Secretary of State,,DEM,Paul Damian Wells,39
+Lane,0057 3 EUGENE 433,Secretary of State,,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,Secretary of State,,DEM,Under Votes,56
+Lane,0044 3 EUGENE 103,Secretary of State,,DEM,Bill Bradbury,1474
+Lane,0044 3 EUGENE 103,Secretary of State,,DEM,Paul Damian Wells,69
+Lane,0044 3 EUGENE 103,Secretary of State,,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,Secretary of State,,DEM,Under Votes,165
+Lane,0041 0 OAKRIDGE,Secretary of State,,DEM,Bill Bradbury,333
+Lane,0041 0 OAKRIDGE,Secretary of State,,DEM,Paul Damian Wells,54
+Lane,0041 0 OAKRIDGE,Secretary of State,,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,Secretary of State,,DEM,Under Votes,55
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,DEM,Peter A. Defazio,838
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,DEM,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,DEM,Under Votes,66
+Lane,0064 3 EUGENE 613,U.S. House,4,DEM,Peter A. Defazio,806
+Lane,0064 3 EUGENE 613,U.S. House,4,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,U.S. House,4,DEM,Under Votes,73
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,DEM,Peter A. Defazio,204
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,DEM,Under Votes,27
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,DEM,Peter A. Defazio,679
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,DEM,Under Votes,33
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,DEM,Peter A. Defazio,685
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,DEM,Under Votes,38
+Lane,0072 3 EUGENE 723,U.S. House,4,DEM,Peter A. Defazio,1110
+Lane,0072 3 EUGENE 723,U.S. House,4,DEM,Over Votes,0
+Lane,0072 3 EUGENE 723,U.S. House,4,DEM,Under Votes,70
+Lane,0070 7 EUGENE 717,U.S. House,4,DEM,Peter A. Defazio,65
+Lane,0070 7 EUGENE 717,U.S. House,4,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,U.S. House,4,DEM,Under Votes,6
+Lane,0074 5 EUGENE 805,U.S. House,4,DEM,Peter A. Defazio,352
+Lane,0074 5 EUGENE 805,U.S. House,4,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,U.S. House,4,DEM,Under Votes,20
+Lane,0065 7 EUGENE 617,U.S. House,4,DEM,Peter A. Defazio,723
+Lane,0065 7 EUGENE 617,U.S. House,4,DEM,Over Votes,0
+Lane,0065 7 EUGENE 617,U.S. House,4,DEM,Under Votes,53
+Lane,0069 5 EUGENE 715,U.S. House,4,DEM,Peter A. Defazio,68
+Lane,0069 5 EUGENE 715,U.S. House,4,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,U.S. House,4,DEM,Under Votes,7
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,DEM,Peter A. Defazio,802
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,DEM,Under Votes,56
+Lane,0067 1 EUGENE 711,U.S. House,4,DEM,Peter A. Defazio,256
+Lane,0067 1 EUGENE 711,U.S. House,4,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,U.S. House,4,DEM,Under Votes,14
+Lane,0071 9 EUGENE 719,U.S. House,4,DEM,Peter A. Defazio,56
+Lane,0071 9 EUGENE 719,U.S. House,4,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,U.S. House,4,DEM,Under Votes,7
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,DEM,Peter A. Defazio,573
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,DEM,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,DEM,Under Votes,52
+Lane,0068 3 EUGENE 713,U.S. House,4,DEM,Peter A. Defazio,448
+Lane,0068 3 EUGENE 713,U.S. House,4,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,U.S. House,4,DEM,Under Votes,22
+Lane,0075 7 EUGENE 807,U.S. House,4,DEM,Peter A. Defazio,1101
+Lane,0075 7 EUGENE 807,U.S. House,4,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,U.S. House,4,DEM,Under Votes,97
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,DEM,Peter A. Defazio,707
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,DEM,Under Votes,37
+Lane,0073 3 EUGENE 803,U.S. House,4,DEM,Peter A. Defazio,465
+Lane,0073 3 EUGENE 803,U.S. House,4,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,U.S. House,4,DEM,Under Votes,31
+Lane,0066 3 EUGENE 623,U.S. House,4,DEM,Peter A. Defazio,530
+Lane,0066 3 EUGENE 623,U.S. House,4,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,U.S. House,4,DEM,Under Votes,34
+Lane,0076 9 EUGENE 809,U.S. House,4,DEM,Peter A. Defazio,278
+Lane,0076 9 EUGENE 809,U.S. House,4,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,U.S. House,4,DEM,Under Votes,25
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,DEM,Bill Bradbury,734
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,DEM,Paul Damian Wells,99
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,DEM,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,DEM,Under Votes,80
+Lane,0064 3 EUGENE 613,Secretary of State,,DEM,Bill Bradbury,707
+Lane,0064 3 EUGENE 613,Secretary of State,,DEM,Paul Damian Wells,87
+Lane,0064 3 EUGENE 613,Secretary of State,,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,Secretary of State,,DEM,Under Votes,89
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,DEM,Bill Bradbury,177
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,DEM,Paul Damian Wells,22
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,DEM,Under Votes,32
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,DEM,Bill Bradbury,555
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,DEM,Paul Damian Wells,100
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,DEM,Over Votes,1
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,DEM,Under Votes,58
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,DEM,Bill Bradbury,588
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,DEM,Paul Damian Wells,66
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,DEM,Over Votes,1
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,DEM,Under Votes,71
+Lane,0072 3 EUGENE 723,Secretary of State,,DEM,Bill Bradbury,944
+Lane,0072 3 EUGENE 723,Secretary of State,,DEM,Paul Damian Wells,111
+Lane,0072 3 EUGENE 723,Secretary of State,,DEM,Over Votes,1
+Lane,0072 3 EUGENE 723,Secretary of State,,DEM,Under Votes,125
+Lane,0070 7 EUGENE 717,Secretary of State,,DEM,Bill Bradbury,60
+Lane,0070 7 EUGENE 717,Secretary of State,,DEM,Paul Damian Wells,4
+Lane,0070 7 EUGENE 717,Secretary of State,,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,Secretary of State,,DEM,Under Votes,7
+Lane,0074 5 EUGENE 805,Secretary of State,,DEM,Bill Bradbury,290
+Lane,0074 5 EUGENE 805,Secretary of State,,DEM,Paul Damian Wells,54
+Lane,0074 5 EUGENE 805,Secretary of State,,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,Secretary of State,,DEM,Under Votes,25
+Lane,0065 7 EUGENE 617,Secretary of State,,DEM,Bill Bradbury,629
+Lane,0065 7 EUGENE 617,Secretary of State,,DEM,Paul Damian Wells,83
+Lane,0065 7 EUGENE 617,Secretary of State,,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,Secretary of State,,DEM,Under Votes,67
+Lane,0069 5 EUGENE 715,Secretary of State,,DEM,Bill Bradbury,63
+Lane,0069 5 EUGENE 715,Secretary of State,,DEM,Paul Damian Wells,6
+Lane,0069 5 EUGENE 715,Secretary of State,,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,Secretary of State,,DEM,Under Votes,6
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,DEM,Bill Bradbury,688
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,DEM,Paul Damian Wells,71
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,DEM,Under Votes,100
+Lane,0067 1 EUGENE 711,Secretary of State,,DEM,Bill Bradbury,195
+Lane,0067 1 EUGENE 711,Secretary of State,,DEM,Paul Damian Wells,37
+Lane,0067 1 EUGENE 711,Secretary of State,,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,Secretary of State,,DEM,Under Votes,37
+Lane,0071 9 EUGENE 719,Secretary of State,,DEM,Bill Bradbury,51
+Lane,0071 9 EUGENE 719,Secretary of State,,DEM,Paul Damian Wells,4
+Lane,0071 9 EUGENE 719,Secretary of State,,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,Secretary of State,,DEM,Under Votes,8
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,DEM,Bill Bradbury,488
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,DEM,Paul Damian Wells,70
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,DEM,Over Votes,1
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,DEM,Under Votes,68
+Lane,0068 3 EUGENE 713,Secretary of State,,DEM,Bill Bradbury,390
+Lane,0068 3 EUGENE 713,Secretary of State,,DEM,Paul Damian Wells,39
+Lane,0068 3 EUGENE 713,Secretary of State,,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,Secretary of State,,DEM,Under Votes,41
+Lane,0075 7 EUGENE 807,Secretary of State,,DEM,Bill Bradbury,1015
+Lane,0075 7 EUGENE 807,Secretary of State,,DEM,Paul Damian Wells,54
+Lane,0075 7 EUGENE 807,Secretary of State,,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,Secretary of State,,DEM,Under Votes,129
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,DEM,Bill Bradbury,568
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,DEM,Paul Damian Wells,107
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,DEM,Under Votes,73
+Lane,0073 3 EUGENE 803,Secretary of State,,DEM,Bill Bradbury,407
+Lane,0073 3 EUGENE 803,Secretary of State,,DEM,Paul Damian Wells,48
+Lane,0073 3 EUGENE 803,Secretary of State,,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,Secretary of State,,DEM,Under Votes,42
+Lane,0066 3 EUGENE 623,Secretary of State,,DEM,Bill Bradbury,441
+Lane,0066 3 EUGENE 623,Secretary of State,,DEM,Paul Damian Wells,58
+Lane,0066 3 EUGENE 623,Secretary of State,,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,Secretary of State,,DEM,Under Votes,61
+Lane,0076 9 EUGENE 809,Secretary of State,,DEM,Bill Bradbury,235
+Lane,0076 9 EUGENE 809,Secretary of State,,DEM,Paul Damian Wells,36
+Lane,0076 9 EUGENE 809,Secretary of State,,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,Secretary of State,,DEM,Under Votes,31
+Lane,0033 5 MCKENZIE,State Treasurer,,DEM,Randall Edwards,442
+Lane,0033 5 MCKENZIE,State Treasurer,,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,State Treasurer,,DEM,Under Votes,179
+Lane,0026 9 SALMON CREEK,State Treasurer,,DEM,Randall Edwards,118
+Lane,0026 9 SALMON CREEK,State Treasurer,,DEM,Over Votes,1
+Lane,0026 9 SALMON CREEK,State Treasurer,,DEM,Under Votes,46
+Lane,0013 7 GLENADA,State Treasurer,,DEM,Randall Edwards,220
+Lane,0013 7 GLENADA,State Treasurer,,DEM,Over Votes,0
+Lane,0013 7 GLENADA,State Treasurer,,DEM,Under Votes,89
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,DEM,Randall Edwards,640
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,DEM,Under Votes,226
+Lane,0010 2 FERNRIDGE,State Treasurer,,DEM,Randall Edwards,260
+Lane,0010 2 FERNRIDGE,State Treasurer,,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,State Treasurer,,DEM,Under Votes,126
+Lane,0002 3 ARMITAGE,State Treasurer,,DEM,Randall Edwards,158
+Lane,0002 3 ARMITAGE,State Treasurer,,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,State Treasurer,,DEM,Under Votes,85
+Lane,0030 0 SIUSLAW,State Treasurer,,DEM,Randall Edwards,371
+Lane,0030 0 SIUSLAW,State Treasurer,,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,State Treasurer,,DEM,Under Votes,116
+Lane,0052 7 EUGENE 237,State Treasurer,,DEM,Randall Edwards,829
+Lane,0052 7 EUGENE 237,State Treasurer,,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,State Treasurer,,DEM,Under Votes,340
+Lane,0004 5 BLACHLY,State Treasurer,,DEM,Randall Edwards,167
+Lane,0004 5 BLACHLY,State Treasurer,,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,State Treasurer,,DEM,Under Votes,98
+Lane,0063 3 EUGENE 523,State Treasurer,,DEM,Randall Edwards,597
+Lane,0063 3 EUGENE 523,State Treasurer,,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,State Treasurer,,DEM,Under Votes,215
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,DEM,Randall Edwards,655
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,DEM,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,DEM,Under Votes,256
+Lane,0049 5 EUGENE 215,State Treasurer,,DEM,Randall Edwards,997
+Lane,0049 5 EUGENE 215,State Treasurer,,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,State Treasurer,,DEM,Under Votes,439
+Lane,0037 0 DUNES CITY,State Treasurer,,DEM,Randall Edwards,157
+Lane,0037 0 DUNES CITY,State Treasurer,,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,State Treasurer,,DEM,Under Votes,55
+Lane,0042 0 VENETA,State Treasurer,,DEM,Randall Edwards,179
+Lane,0042 0 VENETA,State Treasurer,,DEM,Over Votes,0
+Lane,0042 0 VENETA,State Treasurer,,DEM,Under Votes,81
+Lane,0031 2 WALTERVILLE,State Treasurer,,DEM,Randall Edwards,348
+Lane,0031 2 WALTERVILLE,State Treasurer,,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,State Treasurer,,DEM,Under Votes,137
+Lane,0045 5 EUGENE 105,State Treasurer,,DEM,Randall Edwards,127
+Lane,0045 5 EUGENE 105,State Treasurer,,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,State Treasurer,,DEM,Under Votes,77
+Lane,0062 1 EUGENE 511,State Treasurer,,DEM,Randall Edwards,738
+Lane,0062 1 EUGENE 511,State Treasurer,,DEM,Over Votes,0
+Lane,0062 1 EUGENE 511,State Treasurer,,DEM,Under Votes,345
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,DEM,Randall Edwards,92
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,DEM,Under Votes,68
+Lane,0055 7 EUGENE 317,State Treasurer,,DEM,Randall Edwards,865
+Lane,0055 7 EUGENE 317,State Treasurer,,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,State Treasurer,,DEM,Under Votes,440
+Lane,0039 2 FLORENCE 2,State Treasurer,,DEM,Randall Edwards,485
+Lane,0039 2 FLORENCE 2,State Treasurer,,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,State Treasurer,,DEM,Under Votes,122
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,DEM,Randall Edwards,384
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,DEM,Under Votes,143
+Lane,0060 5 EUGENE 505,State Treasurer,,DEM,Randall Edwards,78
+Lane,0060 5 EUGENE 505,State Treasurer,,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,State Treasurer,,DEM,Under Votes,25
+Lane,0046 7 EUGENE 107,State Treasurer,,DEM,Randall Edwards,146
+Lane,0046 7 EUGENE 107,State Treasurer,,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,State Treasurer,,DEM,Under Votes,87
+Lane,0008 2 CHESHIRE,State Treasurer,,DEM,Randall Edwards,451
+Lane,0008 2 CHESHIRE,State Treasurer,,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,State Treasurer,,DEM,Under Votes,141
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,DEM,Randall Edwards,222
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,DEM,Under Votes,73
+Lane,0058 5 EUGENE 435,State Treasurer,,DEM,Randall Edwards,584
+Lane,0058 5 EUGENE 435,State Treasurer,,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,State Treasurer,,DEM,Under Votes,199
+Lane,0014 0 GOSHEN,State Treasurer,,DEM,Randall Edwards,364
+Lane,0014 0 GOSHEN,State Treasurer,,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,State Treasurer,,DEM,Under Votes,133
+Lane,0018 0 LORANE,State Treasurer,,DEM,Randall Edwards,218
+Lane,0018 0 LORANE,State Treasurer,,DEM,Over Votes,0
+Lane,0018 0 LORANE,State Treasurer,,DEM,Under Votes,106
+Lane,0003 4 BAILEY,State Treasurer,,DEM,Randall Edwards,230
+Lane,0003 4 BAILEY,State Treasurer,,DEM,Over Votes,0
+Lane,0003 4 BAILEY,State Treasurer,,DEM,Under Votes,106
+Lane,0011 4 FOX HOLLOW,State Treasurer,,DEM,Randall Edwards,291
+Lane,0011 4 FOX HOLLOW,State Treasurer,,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State Treasurer,,DEM,Under Votes,110
+Lane,0059 9 EUGENE 439,State Treasurer,,DEM,Randall Edwards,642
+Lane,0059 9 EUGENE 439,State Treasurer,,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,State Treasurer,,DEM,Under Votes,223
+Lane,0061 7 EUGENE 507,State Treasurer,,DEM,Randall Edwards,344
+Lane,0061 7 EUGENE 507,State Treasurer,,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,State Treasurer,,DEM,Under Votes,127
+Lane,0034 0 COBURG,State Treasurer,,DEM,Randall Edwards,96
+Lane,0034 0 COBURG,State Treasurer,,DEM,Over Votes,0
+Lane,0034 0 COBURG,State Treasurer,,DEM,Under Votes,44
+Lane,0038 1 FLORENCE 1,State Treasurer,,DEM,Randall Edwards,454
+Lane,0038 1 FLORENCE 1,State Treasurer,,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,State Treasurer,,DEM,Under Votes,126
+Lane,0051 5 EUGENE 235,State Treasurer,,DEM,Randall Edwards,705
+Lane,0051 5 EUGENE 235,State Treasurer,,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,State Treasurer,,DEM,Under Votes,351
+Lane,0016 5 GATEWAY,State Treasurer,,DEM,Randall Edwards,177
+Lane,0016 5 GATEWAY,State Treasurer,,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,State Treasurer,,DEM,Under Votes,58
+Lane,0021 5 MARCOLA,State Treasurer,,DEM,Randall Edwards,197
+Lane,0021 5 MARCOLA,State Treasurer,,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,State Treasurer,,DEM,Under Votes,74
+Lane,0019 2 LOWELL,State Treasurer,,DEM,Randall Edwards,192
+Lane,0019 2 LOWELL,State Treasurer,,DEM,Over Votes,0
+Lane,0019 2 LOWELL,State Treasurer,,DEM,Under Votes,85
+Lane,0017 7 LATHAM,State Treasurer,,DEM,Randall Edwards,299
+Lane,0017 7 LATHAM,State Treasurer,,DEM,Over Votes,0
+Lane,0017 7 LATHAM,State Treasurer,,DEM,Under Votes,134
+Lane,0048 7 EUGENE 117,State Treasurer,,DEM,Randall Edwards,212
+Lane,0048 7 EUGENE 117,State Treasurer,,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,State Treasurer,,DEM,Under Votes,148
+Lane,0006 8 COAST FORK,State Treasurer,,DEM,Randall Edwards,248
+Lane,0006 8 COAST FORK,State Treasurer,,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,State Treasurer,,DEM,Under Votes,102
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,DEM,Randall Edwards,565
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,DEM,Under Votes,317
+Lane,0050 3 EUGENE 223,State Treasurer,,DEM,Randall Edwards,869
+Lane,0050 3 EUGENE 223,State Treasurer,,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,State Treasurer,,DEM,Under Votes,398
+Lane,0009 0 ELMIRA,State Treasurer,,DEM,Randall Edwards,335
+Lane,0009 0 ELMIRA,State Treasurer,,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,State Treasurer,,DEM,Under Votes,179
+Lane,0025 6 RIVER ROAD,State Treasurer,,DEM,Randall Edwards,896
+Lane,0025 6 RIVER ROAD,State Treasurer,,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,State Treasurer,,DEM,Under Votes,383
+Lane,0022 7 MOSBY,State Treasurer,,DEM,Randall Edwards,491
+Lane,0022 7 MOSBY,State Treasurer,,DEM,Over Votes,0
+Lane,0022 7 MOSBY,State Treasurer,,DEM,Under Votes,262
+Lane,0053 3 EUGENE 313,State Treasurer,,DEM,Randall Edwards,269
+Lane,0053 3 EUGENE 313,State Treasurer,,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,State Treasurer,,DEM,Under Votes,125
+Lane,0020 3 MAPLETON,State Treasurer,,DEM,Randall Edwards,153
+Lane,0020 3 MAPLETON,State Treasurer,,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,State Treasurer,,DEM,Under Votes,56
+Lane,0001 1 ALVADORE,State Treasurer,,DEM,Randall Edwards,220
+Lane,0001 1 ALVADORE,State Treasurer,,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,State Treasurer,,DEM,Under Votes,98
+Lane,0056 1 EUGENE 431,State Treasurer,,DEM,Randall Edwards,189
+Lane,0056 1 EUGENE 431,State Treasurer,,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,State Treasurer,,DEM,Under Votes,55
+Lane,0047 9 EUGENE 109,State Treasurer,,DEM,Randall Edwards,17
+Lane,0047 9 EUGENE 109,State Treasurer,,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,State Treasurer,,DEM,Under Votes,9
+Lane,0015 1 GROVEDALE,State Treasurer,,DEM,Randall Edwards,189
+Lane,0015 1 GROVEDALE,State Treasurer,,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,State Treasurer,,DEM,Under Votes,66
+Lane,0054 5 EUGENE 315,State Treasurer,,DEM,Randall Edwards,757
+Lane,0054 5 EUGENE 315,State Treasurer,,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,State Treasurer,,DEM,Under Votes,378
+Lane,0043 1 EUGENE 101,State Treasurer,,DEM,Randall Edwards,980
+Lane,0043 1 EUGENE 101,State Treasurer,,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,State Treasurer,,DEM,Under Votes,492
+Lane,0005 7 BLUE RIVER,State Treasurer,,DEM,Randall Edwards,265
+Lane,0005 7 BLUE RIVER,State Treasurer,,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,State Treasurer,,DEM,Under Votes,102
+Lane,0007 9 CAMAS,State Treasurer,,DEM,Randall Edwards,60
+Lane,0007 9 CAMAS,State Treasurer,,DEM,Over Votes,0
+Lane,0007 9 CAMAS,State Treasurer,,DEM,Under Votes,36
+Lane,0036 0 CRESWELL,State Treasurer,,DEM,Randall Edwards,227
+Lane,0036 0 CRESWELL,State Treasurer,,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,State Treasurer,,DEM,Under Votes,73
+Lane,0012 6 GARDEN WAY,State Treasurer,,DEM,Randall Edwards,67
+Lane,0012 6 GARDEN WAY,State Treasurer,,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,State Treasurer,,DEM,Under Votes,21
+Lane,0032 3 WILKINS,State Treasurer,,DEM,Randall Edwards,243
+Lane,0032 3 WILKINS,State Treasurer,,DEM,Over Votes,0
+Lane,0032 3 WILKINS,State Treasurer,,DEM,Under Votes,114
+Lane,0040 0 JUNCTION CITY,State Treasurer,,DEM,Randall Edwards,279
+Lane,0040 0 JUNCTION CITY,State Treasurer,,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,State Treasurer,,DEM,Under Votes,85
+Lane,0057 3 EUGENE 433,State Treasurer,,DEM,Randall Edwards,461
+Lane,0057 3 EUGENE 433,State Treasurer,,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,State Treasurer,,DEM,Under Votes,160
+Lane,0044 3 EUGENE 103,State Treasurer,,DEM,Randall Edwards,1141
+Lane,0044 3 EUGENE 103,State Treasurer,,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,State Treasurer,,DEM,Under Votes,567
+Lane,0041 0 OAKRIDGE,State Treasurer,,DEM,Randall Edwards,322
+Lane,0041 0 OAKRIDGE,State Treasurer,,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,State Treasurer,,DEM,Under Votes,120
+Lane,0033 5 MCKENZIE,Attorney General,,DEM,Hardy Myers,456
+Lane,0033 5 MCKENZIE,Attorney General,,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,Attorney General,,DEM,Under Votes,163
+Lane,0026 9 SALMON CREEK,Attorney General,,DEM,Hardy Myers,118
+Lane,0026 9 SALMON CREEK,Attorney General,,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,Attorney General,,DEM,Under Votes,47
+Lane,0013 7 GLENADA,Attorney General,,DEM,Hardy Myers,227
+Lane,0013 7 GLENADA,Attorney General,,DEM,Over Votes,0
+Lane,0013 7 GLENADA,Attorney General,,DEM,Under Votes,84
+Lane,0028 4 SANTA CLARA 4,Attorney General,,DEM,Hardy Myers,666
+Lane,0028 4 SANTA CLARA 4,Attorney General,,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,Attorney General,,DEM,Under Votes,200
+Lane,0010 2 FERNRIDGE,Attorney General,,DEM,Hardy Myers,274
+Lane,0010 2 FERNRIDGE,Attorney General,,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,Attorney General,,DEM,Under Votes,114
+Lane,0002 3 ARMITAGE,Attorney General,,DEM,Hardy Myers,169
+Lane,0002 3 ARMITAGE,Attorney General,,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,Attorney General,,DEM,Under Votes,75
+Lane,0030 0 SIUSLAW,Attorney General,,DEM,Hardy Myers,383
+Lane,0030 0 SIUSLAW,Attorney General,,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,Attorney General,,DEM,Under Votes,104
+Lane,0052 7 EUGENE 237,Attorney General,,DEM,Hardy Myers,863
+Lane,0052 7 EUGENE 237,Attorney General,,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,Attorney General,,DEM,Under Votes,309
+Lane,0004 5 BLACHLY,Attorney General,,DEM,Hardy Myers,176
+Lane,0004 5 BLACHLY,Attorney General,,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,Attorney General,,DEM,Under Votes,87
+Lane,0063 3 EUGENE 523,Attorney General,,DEM,Hardy Myers,613
+Lane,0063 3 EUGENE 523,Attorney General,,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,Attorney General,,DEM,Under Votes,198
+Lane,0035 0 COTTAGE GROVE,Attorney General,,DEM,Hardy Myers,651
+Lane,0035 0 COTTAGE GROVE,Attorney General,,DEM,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,Attorney General,,DEM,Under Votes,261
+Lane,0049 5 EUGENE 215,Attorney General,,DEM,Hardy Myers,1026
+Lane,0049 5 EUGENE 215,Attorney General,,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,Attorney General,,DEM,Under Votes,410
+Lane,0037 0 DUNES CITY,Attorney General,,DEM,Hardy Myers,160
+Lane,0037 0 DUNES CITY,Attorney General,,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,Attorney General,,DEM,Under Votes,52
+Lane,0042 0 VENETA,Attorney General,,DEM,Hardy Myers,186
+Lane,0042 0 VENETA,Attorney General,,DEM,Over Votes,0
+Lane,0042 0 VENETA,Attorney General,,DEM,Under Votes,76
+Lane,0031 2 WALTERVILLE,Attorney General,,DEM,Hardy Myers,353
+Lane,0031 2 WALTERVILLE,Attorney General,,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,Attorney General,,DEM,Under Votes,133
+Lane,0045 5 EUGENE 105,Attorney General,,DEM,Hardy Myers,128
+Lane,0045 5 EUGENE 105,Attorney General,,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,Attorney General,,DEM,Under Votes,76
+Lane,0062 1 EUGENE 511,Attorney General,,DEM,Hardy Myers,759
+Lane,0062 1 EUGENE 511,Attorney General,,DEM,Over Votes,0
+Lane,0062 1 EUGENE 511,Attorney General,,DEM,Under Votes,324
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,DEM,Hardy Myers,96
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,DEM,Under Votes,64
+Lane,0055 7 EUGENE 317,Attorney General,,DEM,Hardy Myers,901
+Lane,0055 7 EUGENE 317,Attorney General,,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,Attorney General,,DEM,Under Votes,399
+Lane,0039 2 FLORENCE 2,Attorney General,,DEM,Hardy Myers,489
+Lane,0039 2 FLORENCE 2,Attorney General,,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,Attorney General,,DEM,Under Votes,117
+Lane,0029 8 SANTA CLARA 8,Attorney General,,DEM,Hardy Myers,404
+Lane,0029 8 SANTA CLARA 8,Attorney General,,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,Attorney General,,DEM,Under Votes,124
+Lane,0060 5 EUGENE 505,Attorney General,,DEM,Hardy Myers,81
+Lane,0060 5 EUGENE 505,Attorney General,,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,Attorney General,,DEM,Under Votes,23
+Lane,0046 7 EUGENE 107,Attorney General,,DEM,Hardy Myers,146
+Lane,0046 7 EUGENE 107,Attorney General,,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,Attorney General,,DEM,Under Votes,86
+Lane,0008 2 CHESHIRE,Attorney General,,DEM,Hardy Myers,443
+Lane,0008 2 CHESHIRE,Attorney General,,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,Attorney General,,DEM,Under Votes,147
+Lane,0027 1 SANTA CLARA 1,Attorney General,,DEM,Hardy Myers,227
+Lane,0027 1 SANTA CLARA 1,Attorney General,,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,Attorney General,,DEM,Under Votes,69
+Lane,0058 5 EUGENE 435,Attorney General,,DEM,Hardy Myers,589
+Lane,0058 5 EUGENE 435,Attorney General,,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,Attorney General,,DEM,Under Votes,192
+Lane,0014 0 GOSHEN,Attorney General,,DEM,Hardy Myers,360
+Lane,0014 0 GOSHEN,Attorney General,,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,Attorney General,,DEM,Under Votes,138
+Lane,0018 0 LORANE,Attorney General,,DEM,Hardy Myers,225
+Lane,0018 0 LORANE,Attorney General,,DEM,Over Votes,0
+Lane,0018 0 LORANE,Attorney General,,DEM,Under Votes,100
+Lane,0003 4 BAILEY,Attorney General,,DEM,Hardy Myers,234
+Lane,0003 4 BAILEY,Attorney General,,DEM,Over Votes,0
+Lane,0003 4 BAILEY,Attorney General,,DEM,Under Votes,102
+Lane,0011 4 FOX HOLLOW,Attorney General,,DEM,Hardy Myers,298
+Lane,0011 4 FOX HOLLOW,Attorney General,,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,Attorney General,,DEM,Under Votes,102
+Lane,0059 9 EUGENE 439,Attorney General,,DEM,Hardy Myers,664
+Lane,0059 9 EUGENE 439,Attorney General,,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,Attorney General,,DEM,Under Votes,200
+Lane,0061 7 EUGENE 507,Attorney General,,DEM,Hardy Myers,349
+Lane,0061 7 EUGENE 507,Attorney General,,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,Attorney General,,DEM,Under Votes,121
+Lane,0034 0 COBURG,Attorney General,,DEM,Hardy Myers,105
+Lane,0034 0 COBURG,Attorney General,,DEM,Over Votes,0
+Lane,0034 0 COBURG,Attorney General,,DEM,Under Votes,36
+Lane,0038 1 FLORENCE 1,Attorney General,,DEM,Hardy Myers,457
+Lane,0038 1 FLORENCE 1,Attorney General,,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,Attorney General,,DEM,Under Votes,123
+Lane,0051 5 EUGENE 235,Attorney General,,DEM,Hardy Myers,738
+Lane,0051 5 EUGENE 235,Attorney General,,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,Attorney General,,DEM,Under Votes,319
+Lane,0016 5 GATEWAY,Attorney General,,DEM,Hardy Myers,185
+Lane,0016 5 GATEWAY,Attorney General,,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,Attorney General,,DEM,Under Votes,51
+Lane,0021 5 MARCOLA,Attorney General,,DEM,Hardy Myers,196
+Lane,0021 5 MARCOLA,Attorney General,,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,Attorney General,,DEM,Under Votes,74
+Lane,0019 2 LOWELL,Attorney General,,DEM,Hardy Myers,198
+Lane,0019 2 LOWELL,Attorney General,,DEM,Over Votes,0
+Lane,0019 2 LOWELL,Attorney General,,DEM,Under Votes,80
+Lane,0017 7 LATHAM,Attorney General,,DEM,Hardy Myers,301
+Lane,0017 7 LATHAM,Attorney General,,DEM,Over Votes,0
+Lane,0017 7 LATHAM,Attorney General,,DEM,Under Votes,134
+Lane,0048 7 EUGENE 117,Attorney General,,DEM,Hardy Myers,221
+Lane,0048 7 EUGENE 117,Attorney General,,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,Attorney General,,DEM,Under Votes,138
+Lane,0006 8 COAST FORK,Attorney General,,DEM,Hardy Myers,262
+Lane,0006 8 COAST FORK,Attorney General,,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,Attorney General,,DEM,Under Votes,88
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,DEM,Hardy Myers,580
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,DEM,Under Votes,303
+Lane,0050 3 EUGENE 223,Attorney General,,DEM,Hardy Myers,902
+Lane,0050 3 EUGENE 223,Attorney General,,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,Attorney General,,DEM,Under Votes,363
+Lane,0009 0 ELMIRA,Attorney General,,DEM,Hardy Myers,341
+Lane,0009 0 ELMIRA,Attorney General,,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,Attorney General,,DEM,Under Votes,173
+Lane,0025 6 RIVER ROAD,Attorney General,,DEM,Hardy Myers,923
+Lane,0025 6 RIVER ROAD,Attorney General,,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,Attorney General,,DEM,Under Votes,356
+Lane,0022 7 MOSBY,Attorney General,,DEM,Hardy Myers,502
+Lane,0022 7 MOSBY,Attorney General,,DEM,Over Votes,0
+Lane,0022 7 MOSBY,Attorney General,,DEM,Under Votes,252
+Lane,0053 3 EUGENE 313,Attorney General,,DEM,Hardy Myers,273
+Lane,0053 3 EUGENE 313,Attorney General,,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,Attorney General,,DEM,Under Votes,121
+Lane,0020 3 MAPLETON,Attorney General,,DEM,Hardy Myers,153
+Lane,0020 3 MAPLETON,Attorney General,,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,Attorney General,,DEM,Under Votes,56
+Lane,0001 1 ALVADORE,Attorney General,,DEM,Hardy Myers,219
+Lane,0001 1 ALVADORE,Attorney General,,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,Attorney General,,DEM,Under Votes,98
+Lane,0056 1 EUGENE 431,Attorney General,,DEM,Hardy Myers,194
+Lane,0056 1 EUGENE 431,Attorney General,,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,Attorney General,,DEM,Under Votes,52
+Lane,0047 9 EUGENE 109,Attorney General,,DEM,Hardy Myers,16
+Lane,0047 9 EUGENE 109,Attorney General,,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,Attorney General,,DEM,Under Votes,10
+Lane,0015 1 GROVEDALE,Attorney General,,DEM,Hardy Myers,194
+Lane,0015 1 GROVEDALE,Attorney General,,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,Attorney General,,DEM,Under Votes,62
+Lane,0054 5 EUGENE 315,Attorney General,,DEM,Hardy Myers,777
+Lane,0054 5 EUGENE 315,Attorney General,,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,Attorney General,,DEM,Under Votes,353
+Lane,0043 1 EUGENE 101,Attorney General,,DEM,Hardy Myers,1003
+Lane,0043 1 EUGENE 101,Attorney General,,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,Attorney General,,DEM,Under Votes,472
+Lane,0005 7 BLUE RIVER,Attorney General,,DEM,Hardy Myers,266
+Lane,0005 7 BLUE RIVER,Attorney General,,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,Attorney General,,DEM,Under Votes,101
+Lane,0007 9 CAMAS,Attorney General,,DEM,Hardy Myers,62
+Lane,0007 9 CAMAS,Attorney General,,DEM,Over Votes,0
+Lane,0007 9 CAMAS,Attorney General,,DEM,Under Votes,35
+Lane,0036 0 CRESWELL,Attorney General,,DEM,Hardy Myers,226
+Lane,0036 0 CRESWELL,Attorney General,,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,Attorney General,,DEM,Under Votes,75
+Lane,0012 6 GARDEN WAY,Attorney General,,DEM,Hardy Myers,65
+Lane,0012 6 GARDEN WAY,Attorney General,,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,Attorney General,,DEM,Under Votes,23
+Lane,0032 3 WILKINS,Attorney General,,DEM,Hardy Myers,250
+Lane,0032 3 WILKINS,Attorney General,,DEM,Over Votes,0
+Lane,0032 3 WILKINS,Attorney General,,DEM,Under Votes,106
+Lane,0040 0 JUNCTION CITY,Attorney General,,DEM,Hardy Myers,277
+Lane,0040 0 JUNCTION CITY,Attorney General,,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,Attorney General,,DEM,Under Votes,82
+Lane,0057 3 EUGENE 433,Attorney General,,DEM,Hardy Myers,483
+Lane,0057 3 EUGENE 433,Attorney General,,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,Attorney General,,DEM,Under Votes,138
+Lane,0044 3 EUGENE 103,Attorney General,,DEM,Hardy Myers,1189
+Lane,0044 3 EUGENE 103,Attorney General,,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,Attorney General,,DEM,Under Votes,520
+Lane,0041 0 OAKRIDGE,Attorney General,,DEM,Hardy Myers,333
+Lane,0041 0 OAKRIDGE,Attorney General,,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,Attorney General,,DEM,Under Votes,109
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,DEM,Randall Edwards,668
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,DEM,Over Votes,1
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,DEM,Under Votes,237
+Lane,0064 3 EUGENE 613,State Treasurer,,DEM,Randall Edwards,648
+Lane,0064 3 EUGENE 613,State Treasurer,,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,State Treasurer,,DEM,Under Votes,233
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,DEM,Randall Edwards,148
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,DEM,Under Votes,83
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,DEM,Randall Edwards,550
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,DEM,Under Votes,163
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,DEM,Randall Edwards,562
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,DEM,Under Votes,162
+Lane,0072 3 EUGENE 723,State Treasurer,,DEM,Randall Edwards,756
+Lane,0072 3 EUGENE 723,State Treasurer,,DEM,Over Votes,0
+Lane,0072 3 EUGENE 723,State Treasurer,,DEM,Under Votes,421
+Lane,0070 7 EUGENE 717,State Treasurer,,DEM,Randall Edwards,50
+Lane,0070 7 EUGENE 717,State Treasurer,,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,State Treasurer,,DEM,Under Votes,21
+Lane,0074 5 EUGENE 805,State Treasurer,,DEM,Randall Edwards,267
+Lane,0074 5 EUGENE 805,State Treasurer,,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,State Treasurer,,DEM,Under Votes,99
+Lane,0065 7 EUGENE 617,State Treasurer,,DEM,Randall Edwards,607
+Lane,0065 7 EUGENE 617,State Treasurer,,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,State Treasurer,,DEM,Under Votes,170
+Lane,0069 5 EUGENE 715,State Treasurer,,DEM,Randall Edwards,56
+Lane,0069 5 EUGENE 715,State Treasurer,,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,State Treasurer,,DEM,Under Votes,19
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,DEM,Randall Edwards,637
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,DEM,Under Votes,220
+Lane,0067 1 EUGENE 711,State Treasurer,,DEM,Randall Edwards,186
+Lane,0067 1 EUGENE 711,State Treasurer,,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,State Treasurer,,DEM,Under Votes,84
+Lane,0071 9 EUGENE 719,State Treasurer,,DEM,Randall Edwards,42
+Lane,0071 9 EUGENE 719,State Treasurer,,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,State Treasurer,,DEM,Under Votes,21
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,DEM,Randall Edwards,466
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,DEM,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,DEM,Under Votes,161
+Lane,0068 3 EUGENE 713,State Treasurer,,DEM,Randall Edwards,347
+Lane,0068 3 EUGENE 713,State Treasurer,,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,State Treasurer,,DEM,Under Votes,123
+Lane,0075 7 EUGENE 807,State Treasurer,,DEM,Randall Edwards,835
+Lane,0075 7 EUGENE 807,State Treasurer,,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,State Treasurer,,DEM,Under Votes,359
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,DEM,Randall Edwards,585
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,DEM,Under Votes,160
+Lane,0073 3 EUGENE 803,State Treasurer,,DEM,Randall Edwards,361
+Lane,0073 3 EUGENE 803,State Treasurer,,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,State Treasurer,,DEM,Under Votes,134
+Lane,0066 3 EUGENE 623,State Treasurer,,DEM,Randall Edwards,417
+Lane,0066 3 EUGENE 623,State Treasurer,,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,State Treasurer,,DEM,Under Votes,141
+Lane,0076 9 EUGENE 809,State Treasurer,,DEM,Randall Edwards,209
+Lane,0076 9 EUGENE 809,State Treasurer,,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,State Treasurer,,DEM,Under Votes,92
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,DEM,Hardy Myers,675
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,DEM,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,DEM,Under Votes,232
+Lane,0064 3 EUGENE 613,Attorney General,,DEM,Hardy Myers,664
+Lane,0064 3 EUGENE 613,Attorney General,,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,Attorney General,,DEM,Under Votes,220
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,DEM,Hardy Myers,154
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,DEM,Under Votes,75
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,DEM,Hardy Myers,563
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,DEM,Under Votes,145
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,DEM,Hardy Myers,573
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,DEM,Under Votes,152
+Lane,0072 3 EUGENE 723,Attorney General,,DEM,Hardy Myers,776
+Lane,0072 3 EUGENE 723,Attorney General,,DEM,Over Votes,0
+Lane,0072 3 EUGENE 723,Attorney General,,DEM,Under Votes,397
+Lane,0070 7 EUGENE 717,Attorney General,,DEM,Hardy Myers,53
+Lane,0070 7 EUGENE 717,Attorney General,,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,Attorney General,,DEM,Under Votes,17
+Lane,0074 5 EUGENE 805,Attorney General,,DEM,Hardy Myers,270
+Lane,0074 5 EUGENE 805,Attorney General,,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,Attorney General,,DEM,Under Votes,95
+Lane,0065 7 EUGENE 617,Attorney General,,DEM,Hardy Myers,612
+Lane,0065 7 EUGENE 617,Attorney General,,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,Attorney General,,DEM,Under Votes,166
+Lane,0069 5 EUGENE 715,Attorney General,,DEM,Hardy Myers,55
+Lane,0069 5 EUGENE 715,Attorney General,,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,Attorney General,,DEM,Under Votes,20
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,DEM,Hardy Myers,651
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,DEM,Under Votes,207
+Lane,0067 1 EUGENE 711,Attorney General,,DEM,Hardy Myers,182
+Lane,0067 1 EUGENE 711,Attorney General,,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,Attorney General,,DEM,Under Votes,86
+Lane,0071 9 EUGENE 719,Attorney General,,DEM,Hardy Myers,42
+Lane,0071 9 EUGENE 719,Attorney General,,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,Attorney General,,DEM,Under Votes,21
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,DEM,Hardy Myers,470
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,DEM,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,DEM,Under Votes,156
+Lane,0068 3 EUGENE 713,Attorney General,,DEM,Hardy Myers,356
+Lane,0068 3 EUGENE 713,Attorney General,,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,Attorney General,,DEM,Under Votes,113
+Lane,0075 7 EUGENE 807,Attorney General,,DEM,Hardy Myers,851
+Lane,0075 7 EUGENE 807,Attorney General,,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,Attorney General,,DEM,Under Votes,341
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,DEM,Hardy Myers,582
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,DEM,Under Votes,159
+Lane,0073 3 EUGENE 803,Attorney General,,DEM,Hardy Myers,366
+Lane,0073 3 EUGENE 803,Attorney General,,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,Attorney General,,DEM,Under Votes,128
+Lane,0066 3 EUGENE 623,Attorney General,,DEM,Hardy Myers,420
+Lane,0066 3 EUGENE 623,Attorney General,,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,Attorney General,,DEM,Under Votes,139
+Lane,0076 9 EUGENE 809,Attorney General,,DEM,Hardy Myers,205
+Lane,0076 9 EUGENE 809,Attorney General,,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,Attorney General,,DEM,Under Votes,95
+Lane,0026 9 SALMON CREEK,State Senate,4,DEM,Floyd Prozanski,122
+Lane,0026 9 SALMON CREEK,State Senate,4,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,State Senate,4,DEM,Under Votes,42
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,DEM,Floyd Prozanski,90
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,DEM,Under Votes,71
+Lane,0010 2 FERNRIDGE,State Senate,4,DEM,Floyd Prozanski,276
+Lane,0010 2 FERNRIDGE,State Senate,4,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,State Senate,4,DEM,Under Votes,110
+Lane,0003 4 BAILEY,State Senate,4,DEM,Floyd Prozanski,244
+Lane,0003 4 BAILEY,State Senate,4,DEM,Over Votes,0
+Lane,0003 4 BAILEY,State Senate,4,DEM,Under Votes,91
+Lane,0052 7 EUGENE 237,State Senate,4,DEM,Floyd Prozanski,911
+Lane,0052 7 EUGENE 237,State Senate,4,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,State Senate,4,DEM,Under Votes,261
+Lane,0035 0 COTTAGE GROVE,State Senate,4,DEM,Floyd Prozanski,613
+Lane,0035 0 COTTAGE GROVE,State Senate,4,DEM,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,State Senate,4,DEM,Under Votes,300
+Lane,0069 5 EUGENE 715,State Senate,4,DEM,Floyd Prozanski,55
+Lane,0069 5 EUGENE 715,State Senate,4,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,State Senate,4,DEM,Under Votes,20
+Lane,0042 0 VENETA,State Senate,4,DEM,Floyd Prozanski,179
+Lane,0042 0 VENETA,State Senate,4,DEM,Over Votes,0
+Lane,0042 0 VENETA,State Senate,4,DEM,Under Votes,83
+Lane,0075 7 EUGENE 807,State Senate,4,DEM,Floyd Prozanski,872
+Lane,0075 7 EUGENE 807,State Senate,4,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,State Senate,4,DEM,Under Votes,322
+Lane,0018 0 LORANE,State Senate,4,DEM,Floyd Prozanski,239
+Lane,0018 0 LORANE,State Senate,4,DEM,Over Votes,0
+Lane,0018 0 LORANE,State Senate,4,DEM,Under Votes,86
+Lane,0011 4 FOX HOLLOW,State Senate,4,DEM,Floyd Prozanski,315
+Lane,0011 4 FOX HOLLOW,State Senate,4,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State Senate,4,DEM,Under Votes,87
+Lane,0051 5 EUGENE 235,State Senate,4,DEM,Floyd Prozanski,830
+Lane,0051 5 EUGENE 235,State Senate,4,DEM,Over Votes,0
+Lane,0051 5 EUGENE 235,State Senate,4,DEM,Under Votes,227
+Lane,0041 0 OAKRIDGE,State Senate,4,DEM,Floyd Prozanski,303
+Lane,0041 0 OAKRIDGE,State Senate,4,DEM,Over Votes,0
+Lane,0041 0 OAKRIDGE,State Senate,4,DEM,Under Votes,137
+Lane,0019 2 LOWELL,State Senate,4,DEM,Floyd Prozanski,193
+Lane,0019 2 LOWELL,State Senate,4,DEM,Over Votes,0
+Lane,0019 2 LOWELL,State Senate,4,DEM,Under Votes,85
+Lane,0017 7 LATHAM,State Senate,4,DEM,Floyd Prozanski,281
+Lane,0017 7 LATHAM,State Senate,4,DEM,Over Votes,0
+Lane,0017 7 LATHAM,State Senate,4,DEM,Under Votes,154
+Lane,0022 7 MOSBY,State Senate,4,DEM,Floyd Prozanski,488
+Lane,0022 7 MOSBY,State Senate,4,DEM,Over Votes,0
+Lane,0022 7 MOSBY,State Senate,4,DEM,Under Votes,265
+Lane,0053 3 EUGENE 313,State Senate,4,DEM,Floyd Prozanski,290
+Lane,0053 3 EUGENE 313,State Senate,4,DEM,Over Votes,0
+Lane,0053 3 EUGENE 313,State Senate,4,DEM,Under Votes,105
+Lane,0054 5 EUGENE 315,State Senate,4,DEM,Floyd Prozanski,890
+Lane,0054 5 EUGENE 315,State Senate,4,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,State Senate,4,DEM,Under Votes,245
+Lane,0070 7 EUGENE 717,State Senate,4,DEM,Floyd Prozanski,53
+Lane,0070 7 EUGENE 717,State Senate,4,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,State Senate,4,DEM,Under Votes,18
+Lane,0005 7 BLUE RIVER,State Senate,4,DEM,Floyd Prozanski,253
+Lane,0005 7 BLUE RIVER,State Senate,4,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,State Senate,4,DEM,Under Votes,114
+Lane,0007 9 CAMAS,State Senate,4,DEM,Floyd Prozanski,64
+Lane,0007 9 CAMAS,State Senate,4,DEM,Over Votes,0
+Lane,0007 9 CAMAS,State Senate,4,DEM,Under Votes,33
+Lane,0043 1 EUGENE 101,State Senate,4,DEM,Floyd Prozanski,1135
+Lane,0043 1 EUGENE 101,State Senate,4,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,State Senate,4,DEM,Under Votes,340
+Lane,0076 9 EUGENE 809,State Senate,4,DEM,Floyd Prozanski,215
+Lane,0076 9 EUGENE 809,State Senate,4,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,State Senate,4,DEM,Under Votes,87
+Lane,0044 3 EUGENE 103,State Senate,4,DEM,Floyd Prozanski,1381
+Lane,0044 3 EUGENE 103,State Senate,4,DEM,Over Votes,0
+Lane,0044 3 EUGENE 103,State Senate,4,DEM,Under Votes,325
+Lane,0020 3 MAPLETON,State Senate,5,DEM,Joanne Verger,149
+Lane,0020 3 MAPLETON,State Senate,5,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,State Senate,5,DEM,Under Votes,60
+Lane,0030 0 SIUSLAW,State Senate,5,DEM,Joanne Verger,362
+Lane,0030 0 SIUSLAW,State Senate,5,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,State Senate,5,DEM,Under Votes,122
+Lane,0013 7 GLENADA,State Senate,5,DEM,Joanne Verger,211
+Lane,0013 7 GLENADA,State Senate,5,DEM,Over Votes,0
+Lane,0013 7 GLENADA,State Senate,5,DEM,Under Votes,96
+Lane,0038 1 FLORENCE 1,State Senate,5,DEM,Joanne Verger,442
+Lane,0038 1 FLORENCE 1,State Senate,5,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,State Senate,5,DEM,Under Votes,138
+Lane,0004 5 BLACHLY,State Senate,5,DEM,Joanne Verger,147
+Lane,0004 5 BLACHLY,State Senate,5,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,State Senate,5,DEM,Under Votes,119
+Lane,0037 0 DUNES CITY,State Senate,5,DEM,Joanne Verger,159
+Lane,0037 0 DUNES CITY,State Senate,5,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,State Senate,5,DEM,Under Votes,53
+Lane,0009 0 ELMIRA,State Senate,5,DEM,Joanne Verger,305
+Lane,0009 0 ELMIRA,State Senate,5,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,State Senate,5,DEM,Under Votes,210
+Lane,0039 2 FLORENCE 2,State Senate,5,DEM,Joanne Verger,480
+Lane,0039 2 FLORENCE 2,State Senate,5,DEM,Over Votes,0
+Lane,0039 2 FLORENCE 2,State Senate,5,DEM,Under Votes,127
+Lane,0026 9 SALMON CREEK,State House,7,DEM,Greg Thorne,46
+Lane,0026 9 SALMON CREEK,State House,7,DEM,Shirley A. Cairns,78
+Lane,0026 9 SALMON CREEK,State House,7,DEM,Over Votes,0
+Lane,0026 9 SALMON CREEK,State House,7,DEM,Under Votes,40
+Lane,0024 2 PLEASANT HILL 2,State House,7,DEM,Greg Thorne,29
+Lane,0024 2 PLEASANT HILL 2,State House,7,DEM,Shirley A. Cairns,74
+Lane,0024 2 PLEASANT HILL 2,State House,7,DEM,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State House,7,DEM,Under Votes,58
+Lane,0017 7 LATHAM,State House,7,DEM,Greg Thorne,92
+Lane,0017 7 LATHAM,State House,7,DEM,Shirley A. Cairns,192
+Lane,0017 7 LATHAM,State House,7,DEM,Over Votes,0
+Lane,0017 7 LATHAM,State House,7,DEM,Under Votes,153
+Lane,0041 0 OAKRIDGE,State House,7,DEM,Greg Thorne,98
+Lane,0041 0 OAKRIDGE,State House,7,DEM,Shirley A. Cairns,199
+Lane,0041 0 OAKRIDGE,State House,7,DEM,Over Votes,1
+Lane,0041 0 OAKRIDGE,State House,7,DEM,Under Votes,141
+Lane,0035 0 COTTAGE GROVE,State House,7,DEM,Greg Thorne,238
+Lane,0035 0 COTTAGE GROVE,State House,7,DEM,Shirley A. Cairns,408
+Lane,0035 0 COTTAGE GROVE,State House,7,DEM,Over Votes,1
+Lane,0035 0 COTTAGE GROVE,State House,7,DEM,Under Votes,271
+Lane,0005 7 BLUE RIVER,State House,7,DEM,Greg Thorne,76
+Lane,0005 7 BLUE RIVER,State House,7,DEM,Shirley A. Cairns,194
+Lane,0005 7 BLUE RIVER,State House,7,DEM,Over Votes,0
+Lane,0005 7 BLUE RIVER,State House,7,DEM,Under Votes,98
+Lane,0019 2 LOWELL,State House,7,DEM,Greg Thorne,63
+Lane,0019 2 LOWELL,State House,7,DEM,Shirley A. Cairns,130
+Lane,0019 2 LOWELL,State House,7,DEM,Over Votes,0
+Lane,0019 2 LOWELL,State House,7,DEM,Under Votes,85
+Lane,0007 9 CAMAS,State House,7,DEM,Greg Thorne,13
+Lane,0007 9 CAMAS,State House,7,DEM,Shirley A. Cairns,45
+Lane,0007 9 CAMAS,State House,7,DEM,Over Votes,0
+Lane,0007 9 CAMAS,State House,7,DEM,Under Votes,37
+Lane,0022 7 MOSBY,State House,7,DEM,Greg Thorne,171
+Lane,0022 7 MOSBY,State House,7,DEM,Shirley A. Cairns,325
+Lane,0022 7 MOSBY,State House,7,DEM,Over Votes,2
+Lane,0022 7 MOSBY,State House,7,DEM,Under Votes,256
+Lane,0051 5 EUGENE 235,State House,8,DEM,Marlene (Mitzi) Colbath,193
+Lane,0051 5 EUGENE 235,State House,8,DEM,Hart Williams,16
+Lane,0051 5 EUGENE 235,State House,8,DEM,Paul R. Holvey,701
+Lane,0051 5 EUGENE 235,State House,8,DEM,Over Votes,2
+Lane,0051 5 EUGENE 235,State House,8,DEM,Under Votes,143
+Lane,0011 4 FOX HOLLOW,State House,8,DEM,Marlene (Mitzi) Colbath,125
+Lane,0011 4 FOX HOLLOW,State House,8,DEM,Hart Williams,9
+Lane,0011 4 FOX HOLLOW,State House,8,DEM,Paul R. Holvey,194
+Lane,0011 4 FOX HOLLOW,State House,8,DEM,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State House,8,DEM,Under Votes,75
+Lane,0053 3 EUGENE 313,State House,8,DEM,Marlene (Mitzi) Colbath,127
+Lane,0053 3 EUGENE 313,State House,8,DEM,Hart Williams,16
+Lane,0053 3 EUGENE 313,State House,8,DEM,Paul R. Holvey,148
+Lane,0053 3 EUGENE 313,State House,8,DEM,Over Votes,1
+Lane,0053 3 EUGENE 313,State House,8,DEM,Under Votes,101
+Lane,0054 5 EUGENE 315,State House,8,DEM,Marlene (Mitzi) Colbath,252
+Lane,0054 5 EUGENE 315,State House,8,DEM,Hart Williams,21
+Lane,0054 5 EUGENE 315,State House,8,DEM,Paul R. Holvey,663
+Lane,0054 5 EUGENE 315,State House,8,DEM,Over Votes,0
+Lane,0054 5 EUGENE 315,State House,8,DEM,Under Votes,195
+Lane,0010 2 FERNRIDGE,State House,8,DEM,Marlene (Mitzi) Colbath,105
+Lane,0010 2 FERNRIDGE,State House,8,DEM,Hart Williams,29
+Lane,0010 2 FERNRIDGE,State House,8,DEM,Paul R. Holvey,161
+Lane,0010 2 FERNRIDGE,State House,8,DEM,Over Votes,0
+Lane,0010 2 FERNRIDGE,State House,8,DEM,Under Votes,93
+Lane,0003 4 BAILEY,State House,8,DEM,Marlene (Mitzi) Colbath,107
+Lane,0003 4 BAILEY,State House,8,DEM,Hart Williams,12
+Lane,0003 4 BAILEY,State House,8,DEM,Paul R. Holvey,150
+Lane,0003 4 BAILEY,State House,8,DEM,Over Votes,0
+Lane,0003 4 BAILEY,State House,8,DEM,Under Votes,65
+Lane,0044 3 EUGENE 103,State House,8,DEM,Marlene (Mitzi) Colbath,377
+Lane,0044 3 EUGENE 103,State House,8,DEM,Hart Williams,35
+Lane,0044 3 EUGENE 103,State House,8,DEM,Paul R. Holvey,1029
+Lane,0044 3 EUGENE 103,State House,8,DEM,Over Votes,1
+Lane,0044 3 EUGENE 103,State House,8,DEM,Under Votes,258
+Lane,0052 7 EUGENE 237,State House,8,DEM,Marlene (Mitzi) Colbath,215
+Lane,0052 7 EUGENE 237,State House,8,DEM,Hart Williams,27
+Lane,0052 7 EUGENE 237,State House,8,DEM,Paul R. Holvey,738
+Lane,0052 7 EUGENE 237,State House,8,DEM,Over Votes,0
+Lane,0052 7 EUGENE 237,State House,8,DEM,Under Votes,191
+Lane,0070 7 EUGENE 717,State House,8,DEM,Marlene (Mitzi) Colbath,25
+Lane,0070 7 EUGENE 717,State House,8,DEM,Hart Williams,1
+Lane,0070 7 EUGENE 717,State House,8,DEM,Paul R. Holvey,26
+Lane,0070 7 EUGENE 717,State House,8,DEM,Over Votes,0
+Lane,0070 7 EUGENE 717,State House,8,DEM,Under Votes,19
+Lane,0043 1 EUGENE 101,State House,8,DEM,Marlene (Mitzi) Colbath,297
+Lane,0043 1 EUGENE 101,State House,8,DEM,Hart Williams,51
+Lane,0043 1 EUGENE 101,State House,8,DEM,Paul R. Holvey,880
+Lane,0043 1 EUGENE 101,State House,8,DEM,Over Votes,0
+Lane,0043 1 EUGENE 101,State House,8,DEM,Under Votes,245
+Lane,0069 5 EUGENE 715,State House,8,DEM,Marlene (Mitzi) Colbath,24
+Lane,0069 5 EUGENE 715,State House,8,DEM,Hart Williams,5
+Lane,0069 5 EUGENE 715,State House,8,DEM,Paul R. Holvey,30
+Lane,0069 5 EUGENE 715,State House,8,DEM,Over Votes,0
+Lane,0069 5 EUGENE 715,State House,8,DEM,Under Votes,16
+Lane,0042 0 VENETA,State House,8,DEM,Marlene (Mitzi) Colbath,88
+Lane,0042 0 VENETA,State House,8,DEM,Hart Williams,24
+Lane,0042 0 VENETA,State House,8,DEM,Paul R. Holvey,107
+Lane,0042 0 VENETA,State House,8,DEM,Over Votes,0
+Lane,0042 0 VENETA,State House,8,DEM,Under Votes,43
+Lane,0075 7 EUGENE 807,State House,8,DEM,Marlene (Mitzi) Colbath,346
+Lane,0075 7 EUGENE 807,State House,8,DEM,Hart Williams,38
+Lane,0075 7 EUGENE 807,State House,8,DEM,Paul R. Holvey,563
+Lane,0075 7 EUGENE 807,State House,8,DEM,Over Votes,0
+Lane,0075 7 EUGENE 807,State House,8,DEM,Under Votes,249
+Lane,0018 0 LORANE,State House,8,DEM,Marlene (Mitzi) Colbath,60
+Lane,0018 0 LORANE,State House,8,DEM,Hart Williams,17
+Lane,0018 0 LORANE,State House,8,DEM,Paul R. Holvey,197
+Lane,0018 0 LORANE,State House,8,DEM,Over Votes,0
+Lane,0018 0 LORANE,State House,8,DEM,Under Votes,49
+Lane,0076 9 EUGENE 809,State House,8,DEM,Marlene (Mitzi) Colbath,99
+Lane,0076 9 EUGENE 809,State House,8,DEM,Hart Williams,13
+Lane,0076 9 EUGENE 809,State House,8,DEM,Paul R. Holvey,139
+Lane,0076 9 EUGENE 809,State House,8,DEM,Over Votes,0
+Lane,0076 9 EUGENE 809,State House,8,DEM,Under Votes,51
+Lane,0039 2 FLORENCE 2,State House,9,DEM,Arnie Roblan,439
+Lane,0039 2 FLORENCE 2,State House,9,DEM,Over Votes,1
+Lane,0039 2 FLORENCE 2,State House,9,DEM,Under Votes,166
+Lane,0038 1 FLORENCE 1,State House,9,DEM,Arnie Roblan,414
+Lane,0038 1 FLORENCE 1,State House,9,DEM,Over Votes,0
+Lane,0038 1 FLORENCE 1,State House,9,DEM,Under Votes,164
+Lane,0013 7 GLENADA,State House,9,DEM,Arnie Roblan,199
+Lane,0013 7 GLENADA,State House,9,DEM,Over Votes,0
+Lane,0013 7 GLENADA,State House,9,DEM,Under Votes,111
+Lane,0037 0 DUNES CITY,State House,9,DEM,Arnie Roblan,145
+Lane,0037 0 DUNES CITY,State House,9,DEM,Over Votes,0
+Lane,0037 0 DUNES CITY,State House,9,DEM,Under Votes,67
+Lane,0004 5 BLACHLY,State House,10,DEM,Jean Cowan,144
+Lane,0004 5 BLACHLY,State House,10,DEM,Over Votes,0
+Lane,0004 5 BLACHLY,State House,10,DEM,Under Votes,120
+Lane,0020 3 MAPLETON,State House,10,DEM,Jean Cowan,144
+Lane,0020 3 MAPLETON,State House,10,DEM,Over Votes,0
+Lane,0020 3 MAPLETON,State House,10,DEM,Under Votes,65
+Lane,0030 0 SIUSLAW,State House,10,DEM,Jean Cowan,332
+Lane,0030 0 SIUSLAW,State House,10,DEM,Over Votes,0
+Lane,0030 0 SIUSLAW,State House,10,DEM,Under Votes,154
+Lane,0009 0 ELMIRA,State House,10,DEM,Jean Cowan,305
+Lane,0009 0 ELMIRA,State House,10,DEM,Over Votes,0
+Lane,0009 0 ELMIRA,State House,10,DEM,Under Votes,211
+Lane,0033 5 MCKENZIE,State House,11,DEM,Phil Barnhart,440
+Lane,0033 5 MCKENZIE,State House,11,DEM,Over Votes,0
+Lane,0033 5 MCKENZIE,State House,11,DEM,Under Votes,182
+Lane,0055 7 EUGENE 317,State House,11,DEM,Phil Barnhart,988
+Lane,0055 7 EUGENE 317,State House,11,DEM,Over Votes,0
+Lane,0055 7 EUGENE 317,State House,11,DEM,Under Votes,315
+Lane,0034 0 COBURG,State House,11,DEM,Phil Barnhart,105
+Lane,0034 0 COBURG,State House,11,DEM,Over Votes,0
+Lane,0034 0 COBURG,State House,11,DEM,Under Votes,35
+Lane,0015 1 GROVEDALE,State House,11,DEM,Phil Barnhart,199
+Lane,0015 1 GROVEDALE,State House,11,DEM,Over Votes,0
+Lane,0015 1 GROVEDALE,State House,11,DEM,Under Votes,57
+Lane,0081 4 SPRINGFIELD 504,State House,11,DEM,Phil Barnhart,7
+Lane,0081 4 SPRINGFIELD 504,State House,11,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State House,11,DEM,Under Votes,2
+Lane,0077 2 SPRINGFIELD 102,State House,11,DEM,Phil Barnhart,1
+Lane,0077 2 SPRINGFIELD 102,State House,11,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State House,11,DEM,Under Votes,2
+Lane,0059 9 EUGENE 439,State House,11,DEM,Phil Barnhart,0
+Lane,0059 9 EUGENE 439,State House,11,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,State House,11,DEM,Under Votes,0
+Lane,0032 3 WILKINS,State House,11,DEM,Phil Barnhart,252
+Lane,0032 3 WILKINS,State House,11,DEM,Over Votes,0
+Lane,0032 3 WILKINS,State House,11,DEM,Under Votes,104
+Lane,0021 5 MARCOLA,State House,11,DEM,Phil Barnhart,198
+Lane,0021 5 MARCOLA,State House,11,DEM,Over Votes,0
+Lane,0021 5 MARCOLA,State House,11,DEM,Under Votes,73
+Lane,0049 5 EUGENE 215,State House,11,DEM,Phil Barnhart,1091
+Lane,0049 5 EUGENE 215,State House,11,DEM,Over Votes,0
+Lane,0049 5 EUGENE 215,State House,11,DEM,Under Votes,345
+Lane,0036 0 CRESWELL,State House,11,DEM,Phil Barnhart,226
+Lane,0036 0 CRESWELL,State House,11,DEM,Over Votes,0
+Lane,0036 0 CRESWELL,State House,11,DEM,Under Votes,75
+Lane,0063 3 EUGENE 523,State House,11,DEM,Phil Barnhart,6
+Lane,0063 3 EUGENE 523,State House,11,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,State House,11,DEM,Under Votes,1
+Lane,0031 2 WALTERVILLE,State House,11,DEM,Phil Barnhart,342
+Lane,0031 2 WALTERVILLE,State House,11,DEM,Over Votes,0
+Lane,0031 2 WALTERVILLE,State House,11,DEM,Under Votes,144
+Lane,0006 8 COAST FORK,State House,11,DEM,Phil Barnhart,259
+Lane,0006 8 COAST FORK,State House,11,DEM,Over Votes,0
+Lane,0006 8 COAST FORK,State House,11,DEM,Under Votes,90
+Lane,0014 0 GOSHEN,State House,11,DEM,Phil Barnhart,358
+Lane,0014 0 GOSHEN,State House,11,DEM,Over Votes,0
+Lane,0014 0 GOSHEN,State House,11,DEM,Under Votes,141
+Lane,0050 3 EUGENE 223,State House,11,DEM,Phil Barnhart,959
+Lane,0050 3 EUGENE 223,State House,11,DEM,Over Votes,0
+Lane,0050 3 EUGENE 223,State House,11,DEM,Under Votes,307
+Lane,0023 1 PLEASANT HILL 1,State House,11,DEM,Phil Barnhart,566
+Lane,0023 1 PLEASANT HILL 1,State House,11,DEM,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,State House,11,DEM,Under Votes,317
+Lane,0079 4 SPRINGFIELD 304,State House,11,DEM,Phil Barnhart,0
+Lane,0079 4 SPRINGFIELD 304,State House,11,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State House,11,DEM,Under Votes,0
+Lane,0078 6 SPRINGFIELD 206,State House,12,DEM,Elizabeth Terry Beyer,668
+Lane,0078 6 SPRINGFIELD 206,State House,12,DEM,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,State House,12,DEM,Under Votes,240
+Lane,0081 4 SPRINGFIELD 504,State House,12,DEM,Elizabeth Terry Beyer,531
+Lane,0081 4 SPRINGFIELD 504,State House,12,DEM,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State House,12,DEM,Under Votes,174
+Lane,0077 2 SPRINGFIELD 102,State House,12,DEM,Elizabeth Terry Beyer,537
+Lane,0077 2 SPRINGFIELD 102,State House,12,DEM,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State House,12,DEM,Under Votes,184
+Lane,0002 3 ARMITAGE,State House,12,DEM,Elizabeth Terry Beyer,162
+Lane,0002 3 ARMITAGE,State House,12,DEM,Over Votes,0
+Lane,0002 3 ARMITAGE,State House,12,DEM,Under Votes,80
+Lane,0016 5 GATEWAY,State House,12,DEM,Elizabeth Terry Beyer,174
+Lane,0016 5 GATEWAY,State House,12,DEM,Over Votes,0
+Lane,0016 5 GATEWAY,State House,12,DEM,Under Votes,61
+Lane,0083 8 SPRINGFIELD 608,State House,12,DEM,Elizabeth Terry Beyer,158
+Lane,0083 8 SPRINGFIELD 608,State House,12,DEM,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,State House,12,DEM,Under Votes,73
+Lane,0080 2 SPRINGFIELD 402,State House,12,DEM,Elizabeth Terry Beyer,554
+Lane,0080 2 SPRINGFIELD 402,State House,12,DEM,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,State House,12,DEM,Under Votes,191
+Lane,0079 4 SPRINGFIELD 304,State House,12,DEM,Elizabeth Terry Beyer,649
+Lane,0079 4 SPRINGFIELD 304,State House,12,DEM,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State House,12,DEM,Under Votes,208
+Lane,0012 6 GARDEN WAY,State House,12,DEM,Elizabeth Terry Beyer,66
+Lane,0012 6 GARDEN WAY,State House,12,DEM,Over Votes,0
+Lane,0012 6 GARDEN WAY,State House,12,DEM,Under Votes,21
+Lane,0082 6 SPRINGFIELD 606,State House,12,DEM,Elizabeth Terry Beyer,459
+Lane,0082 6 SPRINGFIELD 606,State House,12,DEM,Over Votes,1
+Lane,0082 6 SPRINGFIELD 606,State House,12,DEM,Under Votes,166
+Lane,0071 9 EUGENE 719,State House,13,DEM,Robert Ackerman,39
+Lane,0071 9 EUGENE 719,State House,13,DEM,Over Votes,0
+Lane,0071 9 EUGENE 719,State House,13,DEM,Under Votes,24
+Lane,0058 5 EUGENE 435,State House,13,DEM,Robert Ackerman,552
+Lane,0058 5 EUGENE 435,State House,13,DEM,Over Votes,0
+Lane,0058 5 EUGENE 435,State House,13,DEM,Under Votes,228
+Lane,0056 1 EUGENE 431,State House,13,DEM,Robert Ackerman,188
+Lane,0056 1 EUGENE 431,State House,13,DEM,Over Votes,0
+Lane,0056 1 EUGENE 431,State House,13,DEM,Under Votes,58
+Lane,0063 3 EUGENE 523,State House,13,DEM,Robert Ackerman,566
+Lane,0063 3 EUGENE 523,State House,13,DEM,Over Votes,0
+Lane,0063 3 EUGENE 523,State House,13,DEM,Under Votes,236
+Lane,0048 7 EUGENE 117,State House,13,DEM,Robert Ackerman,205
+Lane,0048 7 EUGENE 117,State House,13,DEM,Over Votes,0
+Lane,0048 7 EUGENE 117,State House,13,DEM,Under Votes,154
+Lane,0029 8 SANTA CLARA 8,State House,13,DEM,Robert Ackerman,378
+Lane,0029 8 SANTA CLARA 8,State House,13,DEM,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,State House,13,DEM,Under Votes,148
+Lane,0046 7 EUGENE 107,State House,13,DEM,Robert Ackerman,137
+Lane,0046 7 EUGENE 107,State House,13,DEM,Over Votes,0
+Lane,0046 7 EUGENE 107,State House,13,DEM,Under Votes,96
+Lane,0062 1 EUGENE 511,State House,13,DEM,Robert Ackerman,700
+Lane,0062 1 EUGENE 511,State House,13,DEM,Over Votes,1
+Lane,0062 1 EUGENE 511,State House,13,DEM,Under Votes,381
+Lane,0061 7 EUGENE 507,State House,13,DEM,Robert Ackerman,330
+Lane,0061 7 EUGENE 507,State House,13,DEM,Over Votes,0
+Lane,0061 7 EUGENE 507,State House,13,DEM,Under Votes,140
+Lane,0059 9 EUGENE 439,State House,13,DEM,Robert Ackerman,613
+Lane,0059 9 EUGENE 439,State House,13,DEM,Over Votes,0
+Lane,0059 9 EUGENE 439,State House,13,DEM,Under Votes,252
+Lane,0025 6 RIVER ROAD,State House,13,DEM,Robert Ackerman,909
+Lane,0025 6 RIVER ROAD,State House,13,DEM,Over Votes,0
+Lane,0025 6 RIVER ROAD,State House,13,DEM,Under Votes,371
+Lane,0072 3 EUGENE 723,State House,13,DEM,Robert Ackerman,741
+Lane,0072 3 EUGENE 723,State House,13,DEM,Over Votes,0
+Lane,0072 3 EUGENE 723,State House,13,DEM,Under Votes,434
+Lane,0057 3 EUGENE 433,State House,13,DEM,Robert Ackerman,432
+Lane,0057 3 EUGENE 433,State House,13,DEM,Over Votes,0
+Lane,0057 3 EUGENE 433,State House,13,DEM,Under Votes,189
+Lane,0064 3 EUGENE 613,State House,14,DEM,Bev Ficek,584
+Lane,0064 3 EUGENE 613,State House,14,DEM,Over Votes,0
+Lane,0064 3 EUGENE 613,State House,14,DEM,Under Votes,299
+Lane,0001 1 ALVADORE,State House,14,DEM,Bev Ficek,190
+Lane,0001 1 ALVADORE,State House,14,DEM,Over Votes,0
+Lane,0001 1 ALVADORE,State House,14,DEM,Under Votes,128
+Lane,0047 9 EUGENE 109,State House,14,DEM,Bev Ficek,16
+Lane,0047 9 EUGENE 109,State House,14,DEM,Over Votes,0
+Lane,0047 9 EUGENE 109,State House,14,DEM,Under Votes,10
+Lane,0074 5 EUGENE 805,State House,14,DEM,Bev Ficek,246
+Lane,0074 5 EUGENE 805,State House,14,DEM,Over Votes,0
+Lane,0074 5 EUGENE 805,State House,14,DEM,Under Votes,119
+Lane,0028 4 SANTA CLARA 4,State House,14,DEM,Bev Ficek,591
+Lane,0028 4 SANTA CLARA 4,State House,14,DEM,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,State House,14,DEM,Under Votes,274
+Lane,0060 5 EUGENE 505,State House,14,DEM,Bev Ficek,72
+Lane,0060 5 EUGENE 505,State House,14,DEM,Over Votes,0
+Lane,0060 5 EUGENE 505,State House,14,DEM,Under Votes,31
+Lane,0068 3 EUGENE 713,State House,14,DEM,Bev Ficek,320
+Lane,0068 3 EUGENE 713,State House,14,DEM,Over Votes,0
+Lane,0068 3 EUGENE 713,State House,14,DEM,Under Votes,149
+Lane,0008 2 CHESHIRE,State House,14,DEM,Bev Ficek,394
+Lane,0008 2 CHESHIRE,State House,14,DEM,Over Votes,0
+Lane,0008 2 CHESHIRE,State House,14,DEM,Under Votes,196
+Lane,0027 1 SANTA CLARA 1,State House,14,DEM,Bev Ficek,204
+Lane,0027 1 SANTA CLARA 1,State House,14,DEM,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,State House,14,DEM,Under Votes,89
+Lane,0067 1 EUGENE 711,State House,14,DEM,Bev Ficek,174
+Lane,0067 1 EUGENE 711,State House,14,DEM,Over Votes,0
+Lane,0067 1 EUGENE 711,State House,14,DEM,Under Votes,94
+Lane,0045 5 EUGENE 105,State House,14,DEM,Bev Ficek,107
+Lane,0045 5 EUGENE 105,State House,14,DEM,Over Votes,0
+Lane,0045 5 EUGENE 105,State House,14,DEM,Under Votes,96
+Lane,0040 0 JUNCTION CITY,State House,14,DEM,Bev Ficek,249
+Lane,0040 0 JUNCTION CITY,State House,14,DEM,Over Votes,0
+Lane,0040 0 JUNCTION CITY,State House,14,DEM,Under Votes,108
+Lane,0065 7 EUGENE 617,State House,14,DEM,Bev Ficek,549
+Lane,0065 7 EUGENE 617,State House,14,DEM,Over Votes,1
+Lane,0065 7 EUGENE 617,State House,14,DEM,Under Votes,211
+Lane,0073 3 EUGENE 803,State House,14,DEM,Bev Ficek,317
+Lane,0073 3 EUGENE 803,State House,14,DEM,Over Votes,0
+Lane,0073 3 EUGENE 803,State House,14,DEM,Under Votes,177
+Lane,0066 3 EUGENE 623,State House,14,DEM,Bev Ficek,376
+Lane,0066 3 EUGENE 623,State House,14,DEM,Over Votes,0
+Lane,0066 3 EUGENE 623,State House,14,DEM,Under Votes,180
+Lane,0033 5 MCKENZIE,President,,REP,George W. Bush,579
+Lane,0033 5 MCKENZIE,President,,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,President,,REP,Under Votes,64
+Lane,0026 9 SALMON CREEK,President,,REP,George W. Bush,134
+Lane,0026 9 SALMON CREEK,President,,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,President,,REP,Under Votes,19
+Lane,0013 7 GLENADA,President,,REP,George W. Bush,182
+Lane,0013 7 GLENADA,President,,REP,Over Votes,0
+Lane,0013 7 GLENADA,President,,REP,Under Votes,17
+Lane,0028 4 SANTA CLARA 4,President,,REP,George W. Bush,543
+Lane,0028 4 SANTA CLARA 4,President,,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,President,,REP,Under Votes,50
+Lane,0010 2 FERNRIDGE,President,,REP,George W. Bush,271
+Lane,0010 2 FERNRIDGE,President,,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,President,,REP,Under Votes,25
+Lane,0002 3 ARMITAGE,President,,REP,George W. Bush,152
+Lane,0002 3 ARMITAGE,President,,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,President,,REP,Under Votes,12
+Lane,0030 0 SIUSLAW,President,,REP,George W. Bush,362
+Lane,0030 0 SIUSLAW,President,,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,President,,REP,Under Votes,34
+Lane,0052 7 EUGENE 237,President,,REP,George W. Bush,345
+Lane,0052 7 EUGENE 237,President,,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,President,,REP,Under Votes,93
+Lane,0004 5 BLACHLY,President,,REP,George W. Bush,140
+Lane,0004 5 BLACHLY,President,,REP,Over Votes,0
+Lane,0004 5 BLACHLY,President,,REP,Under Votes,16
+Lane,0063 3 EUGENE 523,President,,REP,George W. Bush,826
+Lane,0063 3 EUGENE 523,President,,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,President,,REP,Under Votes,115
+Lane,0035 0 COTTAGE GROVE,President,,REP,George W. Bush,704
+Lane,0035 0 COTTAGE GROVE,President,,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,President,,REP,Under Votes,59
+Lane,0049 5 EUGENE 215,President,,REP,George W. Bush,401
+Lane,0049 5 EUGENE 215,President,,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,President,,REP,Under Votes,90
+Lane,0037 0 DUNES CITY,President,,REP,George W. Bush,191
+Lane,0037 0 DUNES CITY,President,,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,President,,REP,Under Votes,20
+Lane,0042 0 VENETA,President,,REP,George W. Bush,217
+Lane,0042 0 VENETA,President,,REP,Over Votes,0
+Lane,0042 0 VENETA,President,,REP,Under Votes,18
+Lane,0031 2 WALTERVILLE,President,,REP,George W. Bush,425
+Lane,0031 2 WALTERVILLE,President,,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,President,,REP,Under Votes,32
+Lane,0045 5 EUGENE 105,President,,REP,George W. Bush,41
+Lane,0045 5 EUGENE 105,President,,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,President,,REP,Under Votes,3
+Lane,0062 1 EUGENE 511,President,,REP,George W. Bush,834
+Lane,0062 1 EUGENE 511,President,,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,President,,REP,Under Votes,147
+Lane,0024 2 PLEASANT HILL 2,President,,REP,George W. Bush,77
+Lane,0024 2 PLEASANT HILL 2,President,,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,President,,REP,Under Votes,13
+Lane,0055 7 EUGENE 317,President,,REP,George W. Bush,138
+Lane,0055 7 EUGENE 317,President,,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,President,,REP,Under Votes,67
+Lane,0039 2 FLORENCE 2,President,,REP,George W. Bush,552
+Lane,0039 2 FLORENCE 2,President,,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,President,,REP,Under Votes,65
+Lane,0029 8 SANTA CLARA 8,President,,REP,George W. Bush,283
+Lane,0029 8 SANTA CLARA 8,President,,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,President,,REP,Under Votes,20
+Lane,0060 5 EUGENE 505,President,,REP,George W. Bush,115
+Lane,0060 5 EUGENE 505,President,,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,President,,REP,Under Votes,4
+Lane,0046 7 EUGENE 107,President,,REP,George W. Bush,29
+Lane,0046 7 EUGENE 107,President,,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,President,,REP,Under Votes,5
+Lane,0008 2 CHESHIRE,President,,REP,George W. Bush,563
+Lane,0008 2 CHESHIRE,President,,REP,Over Votes,1
+Lane,0008 2 CHESHIRE,President,,REP,Under Votes,58
+Lane,0027 1 SANTA CLARA 1,President,,REP,George W. Bush,182
+Lane,0027 1 SANTA CLARA 1,President,,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,President,,REP,Under Votes,19
+Lane,0058 5 EUGENE 435,President,,REP,George W. Bush,584
+Lane,0058 5 EUGENE 435,President,,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,President,,REP,Under Votes,103
+Lane,0014 0 GOSHEN,President,,REP,George W. Bush,300
+Lane,0014 0 GOSHEN,President,,REP,Over Votes,0
+Lane,0014 0 GOSHEN,President,,REP,Under Votes,38
+Lane,0018 0 LORANE,President,,REP,George W. Bush,220
+Lane,0018 0 LORANE,President,,REP,Over Votes,0
+Lane,0018 0 LORANE,President,,REP,Under Votes,17
+Lane,0003 4 BAILEY,President,,REP,George W. Bush,263
+Lane,0003 4 BAILEY,President,,REP,Over Votes,0
+Lane,0003 4 BAILEY,President,,REP,Under Votes,30
+Lane,0011 4 FOX HOLLOW,President,,REP,George W. Bush,163
+Lane,0011 4 FOX HOLLOW,President,,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,President,,REP,Under Votes,19
+Lane,0059 9 EUGENE 439,President,,REP,George W. Bush,721
+Lane,0059 9 EUGENE 439,President,,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,President,,REP,Under Votes,111
+Lane,0061 7 EUGENE 507,President,,REP,George W. Bush,345
+Lane,0061 7 EUGENE 507,President,,REP,Over Votes,0
+Lane,0061 7 EUGENE 507,President,,REP,Under Votes,49
+Lane,0034 0 COBURG,President,,REP,George W. Bush,96
+Lane,0034 0 COBURG,President,,REP,Over Votes,0
+Lane,0034 0 COBURG,President,,REP,Under Votes,12
+Lane,0038 1 FLORENCE 1,President,,REP,George W. Bush,429
+Lane,0038 1 FLORENCE 1,President,,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,President,,REP,Under Votes,46
+Lane,0051 5 EUGENE 235,President,,REP,George W. Bush,157
+Lane,0051 5 EUGENE 235,President,,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,President,,REP,Under Votes,51
+Lane,0016 5 GATEWAY,President,,REP,George W. Bush,114
+Lane,0016 5 GATEWAY,President,,REP,Over Votes,0
+Lane,0016 5 GATEWAY,President,,REP,Under Votes,20
+Lane,0021 5 MARCOLA,President,,REP,George W. Bush,146
+Lane,0021 5 MARCOLA,President,,REP,Over Votes,0
+Lane,0021 5 MARCOLA,President,,REP,Under Votes,17
+Lane,0019 2 LOWELL,President,,REP,George W. Bush,179
+Lane,0019 2 LOWELL,President,,REP,Over Votes,0
+Lane,0019 2 LOWELL,President,,REP,Under Votes,27
+Lane,0017 7 LATHAM,President,,REP,George W. Bush,369
+Lane,0017 7 LATHAM,President,,REP,Over Votes,0
+Lane,0017 7 LATHAM,President,,REP,Under Votes,37
+Lane,0048 7 EUGENE 117,President,,REP,George W. Bush,28
+Lane,0048 7 EUGENE 117,President,,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,President,,REP,Under Votes,11
+Lane,0006 8 COAST FORK,President,,REP,George W. Bush,325
+Lane,0006 8 COAST FORK,President,,REP,Over Votes,0
+Lane,0006 8 COAST FORK,President,,REP,Under Votes,40
+Lane,0023 1 PLEASANT HILL 1,President,,REP,George W. Bush,786
+Lane,0023 1 PLEASANT HILL 1,President,,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,President,,REP,Under Votes,126
+Lane,0050 3 EUGENE 223,President,,REP,George W. Bush,324
+Lane,0050 3 EUGENE 223,President,,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,President,,REP,Under Votes,68
+Lane,0009 0 ELMIRA,President,,REP,George W. Bush,310
+Lane,0009 0 ELMIRA,President,,REP,Over Votes,0
+Lane,0009 0 ELMIRA,President,,REP,Under Votes,25
+Lane,0025 6 RIVER ROAD,President,,REP,George W. Bush,436
+Lane,0025 6 RIVER ROAD,President,,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,President,,REP,Under Votes,75
+Lane,0022 7 MOSBY,President,,REP,George W. Bush,636
+Lane,0022 7 MOSBY,President,,REP,Over Votes,0
+Lane,0022 7 MOSBY,President,,REP,Under Votes,70
+Lane,0053 3 EUGENE 313,President,,REP,George W. Bush,58
+Lane,0053 3 EUGENE 313,President,,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,President,,REP,Under Votes,7
+Lane,0020 3 MAPLETON,President,,REP,George W. Bush,119
+Lane,0020 3 MAPLETON,President,,REP,Over Votes,0
+Lane,0020 3 MAPLETON,President,,REP,Under Votes,9
+Lane,0001 1 ALVADORE,President,,REP,George W. Bush,284
+Lane,0001 1 ALVADORE,President,,REP,Over Votes,0
+Lane,0001 1 ALVADORE,President,,REP,Under Votes,15
+Lane,0056 1 EUGENE 431,President,,REP,George W. Bush,132
+Lane,0056 1 EUGENE 431,President,,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,President,,REP,Under Votes,17
+Lane,0047 9 EUGENE 109,President,,REP,George W. Bush,7
+Lane,0047 9 EUGENE 109,President,,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,President,,REP,Under Votes,2
+Lane,0015 1 GROVEDALE,President,,REP,George W. Bush,127
+Lane,0015 1 GROVEDALE,President,,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,President,,REP,Under Votes,28
+Lane,0054 5 EUGENE 315,President,,REP,George W. Bush,124
+Lane,0054 5 EUGENE 315,President,,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,President,,REP,Under Votes,30
+Lane,0043 1 EUGENE 101,President,,REP,George W. Bush,435
+Lane,0043 1 EUGENE 101,President,,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,President,,REP,Under Votes,89
+Lane,0005 7 BLUE RIVER,President,,REP,George W. Bush,221
+Lane,0005 7 BLUE RIVER,President,,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,President,,REP,Under Votes,31
+Lane,0007 9 CAMAS,President,,REP,George W. Bush,69
+Lane,0007 9 CAMAS,President,,REP,Over Votes,0
+Lane,0007 9 CAMAS,President,,REP,Under Votes,8
+Lane,0036 0 CRESWELL,President,,REP,George W. Bush,269
+Lane,0036 0 CRESWELL,President,,REP,Over Votes,0
+Lane,0036 0 CRESWELL,President,,REP,Under Votes,25
+Lane,0012 6 GARDEN WAY,President,,REP,George W. Bush,27
+Lane,0012 6 GARDEN WAY,President,,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,President,,REP,Under Votes,0
+Lane,0032 3 WILKINS,President,,REP,George W. Bush,315
+Lane,0032 3 WILKINS,President,,REP,Over Votes,0
+Lane,0032 3 WILKINS,President,,REP,Under Votes,38
+Lane,0040 0 JUNCTION CITY,President,,REP,George W. Bush,328
+Lane,0040 0 JUNCTION CITY,President,,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,President,,REP,Under Votes,37
+Lane,0057 3 EUGENE 433,President,,REP,George W. Bush,328
+Lane,0057 3 EUGENE 433,President,,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,President,,REP,Under Votes,67
+Lane,0044 3 EUGENE 103,President,,REP,George W. Bush,177
+Lane,0044 3 EUGENE 103,President,,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,President,,REP,Under Votes,62
+Lane,0041 0 OAKRIDGE,President,,REP,George W. Bush,205
+Lane,0041 0 OAKRIDGE,President,,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,President,,REP,Under Votes,30
+Lane,0078 6 SPRINGFIELD 206,President,,REP,George W. Bush,396
+Lane,0078 6 SPRINGFIELD 206,President,,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,President,,REP,Under Votes,39
+Lane,0064 3 EUGENE 613,President,,REP,George W. Bush,499
+Lane,0064 3 EUGENE 613,President,,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,President,,REP,Under Votes,77
+Lane,0083 8 SPRINGFIELD 608,President,,REP,George W. Bush,211
+Lane,0083 8 SPRINGFIELD 608,President,,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,President,,REP,Under Votes,18
+Lane,0081 4 SPRINGFIELD 504,President,,REP,George W. Bush,404
+Lane,0081 4 SPRINGFIELD 504,President,,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,President,,REP,Under Votes,41
+Lane,0077 2 SPRINGFIELD 102,President,,REP,George W. Bush,417
+Lane,0077 2 SPRINGFIELD 102,President,,REP,Over Votes,2
+Lane,0077 2 SPRINGFIELD 102,President,,REP,Under Votes,62
+Lane,0072 3 EUGENE 723,President,,REP,George W. Bush,249
+Lane,0072 3 EUGENE 723,President,,REP,Over Votes,0
+Lane,0072 3 EUGENE 723,President,,REP,Under Votes,44
+Lane,0070 7 EUGENE 717,President,,REP,George W. Bush,21
+Lane,0070 7 EUGENE 717,President,,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,President,,REP,Under Votes,4
+Lane,0074 5 EUGENE 805,President,,REP,George W. Bush,210
+Lane,0074 5 EUGENE 805,President,,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,President,,REP,Under Votes,22
+Lane,0065 7 EUGENE 617,President,,REP,George W. Bush,643
+Lane,0065 7 EUGENE 617,President,,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,President,,REP,Under Votes,78
+Lane,0069 5 EUGENE 715,President,,REP,George W. Bush,14
+Lane,0069 5 EUGENE 715,President,,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,President,,REP,Under Votes,5
+Lane,0079 4 SPRINGFIELD 304,President,,REP,George W. Bush,365
+Lane,0079 4 SPRINGFIELD 304,President,,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,President,,REP,Under Votes,56
+Lane,0067 1 EUGENE 711,President,,REP,George W. Bush,63
+Lane,0067 1 EUGENE 711,President,,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,President,,REP,Under Votes,6
+Lane,0071 9 EUGENE 719,President,,REP,George W. Bush,34
+Lane,0071 9 EUGENE 719,President,,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,President,,REP,Under Votes,13
+Lane,0082 6 SPRINGFIELD 606,President,,REP,George W. Bush,476
+Lane,0082 6 SPRINGFIELD 606,President,,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,President,,REP,Under Votes,41
+Lane,0068 3 EUGENE 713,President,,REP,George W. Bush,482
+Lane,0068 3 EUGENE 713,President,,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,President,,REP,Under Votes,52
+Lane,0075 7 EUGENE 807,President,,REP,George W. Bush,751
+Lane,0075 7 EUGENE 807,President,,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,President,,REP,Under Votes,119
+Lane,0080 2 SPRINGFIELD 402,President,,REP,George W. Bush,464
+Lane,0080 2 SPRINGFIELD 402,President,,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,President,,REP,Under Votes,35
+Lane,0073 3 EUGENE 803,President,,REP,George W. Bush,123
+Lane,0073 3 EUGENE 803,President,,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,President,,REP,Under Votes,22
+Lane,0066 3 EUGENE 623,President,,REP,George W. Bush,458
+Lane,0066 3 EUGENE 623,President,,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,President,,REP,Under Votes,52
+Lane,0076 9 EUGENE 809,President,,REP,George W. Bush,142
+Lane,0076 9 EUGENE 809,President,,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,President,,REP,Under Votes,22
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Pavel Goberman,11
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Al King,334
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Bruce Broussard,58
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,E. Bowerman,26
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Philip Petrie,16
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Thomas Lee Abshier,72
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,U.S. Senate,,REP,Under Votes,151
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Pavel Goberman,4
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Al King,75
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Bruce Broussard,18
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,E. Bowerman,10
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Philip Petrie,7
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Thomas Lee Abshier,14
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,U.S. Senate,,REP,Under Votes,35
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Pavel Goberman,10
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Al King,73
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Bruce Broussard,37
+Lane,0013 7 GLENADA,U.S. Senate,,REP,E. Bowerman,8
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Philip Petrie,15
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Thomas Lee Abshier,17
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Over Votes,0
+Lane,0013 7 GLENADA,U.S. Senate,,REP,Under Votes,45
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Pavel Goberman,19
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Al King,202
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Bruce Broussard,69
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,E. Bowerman,47
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Philip Petrie,22
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Thomas Lee Abshier,106
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,U.S. Senate,,REP,Under Votes,146
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Pavel Goberman,18
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Al King,94
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Bruce Broussard,47
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,E. Bowerman,17
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Philip Petrie,17
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Thomas Lee Abshier,49
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,U.S. Senate,,REP,Under Votes,62
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Pavel Goberman,2
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Al King,85
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Bruce Broussard,17
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,E. Bowerman,8
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Philip Petrie,3
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Thomas Lee Abshier,24
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,U.S. Senate,,REP,Under Votes,32
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Al King,141
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Bruce Broussard,59
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,E. Bowerman,30
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Philip Petrie,16
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Thomas Lee Abshier,45
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,U.S. Senate,,REP,Under Votes,114
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Pavel Goberman,7
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Al King,187
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Bruce Broussard,45
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,E. Bowerman,25
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Philip Petrie,6
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Thomas Lee Abshier,27
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Over Votes,1
+Lane,0052 7 EUGENE 237,U.S. Senate,,REP,Under Votes,170
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Pavel Goberman,8
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Al King,56
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Bruce Broussard,17
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,E. Bowerman,6
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Philip Petrie,4
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Thomas Lee Abshier,23
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Over Votes,0
+Lane,0004 5 BLACHLY,U.S. Senate,,REP,Under Votes,50
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Pavel Goberman,21
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Al King,325
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Bruce Broussard,93
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,E. Bowerman,35
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Philip Petrie,10
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Thomas Lee Abshier,105
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,U.S. Senate,,REP,Under Votes,194
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Pavel Goberman,8
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Al King,184
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Bruce Broussard,64
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,E. Bowerman,35
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Philip Petrie,15
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Thomas Lee Abshier,40
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,U.S. Senate,,REP,Under Votes,183
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Al King,64
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Bruce Broussard,42
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,E. Bowerman,17
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Philip Petrie,11
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Thomas Lee Abshier,29
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,U.S. Senate,,REP,Under Votes,43
+Lane,0042 0 VENETA,U.S. Senate,,REP,Pavel Goberman,15
+Lane,0042 0 VENETA,U.S. Senate,,REP,Al King,69
+Lane,0042 0 VENETA,U.S. Senate,,REP,Bruce Broussard,45
+Lane,0042 0 VENETA,U.S. Senate,,REP,E. Bowerman,10
+Lane,0042 0 VENETA,U.S. Senate,,REP,Philip Petrie,14
+Lane,0042 0 VENETA,U.S. Senate,,REP,Thomas Lee Abshier,45
+Lane,0042 0 VENETA,U.S. Senate,,REP,Over Votes,0
+Lane,0042 0 VENETA,U.S. Senate,,REP,Under Votes,40
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Pavel Goberman,7
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Al King,229
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Bruce Broussard,49
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,E. Bowerman,24
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Philip Petrie,11
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Thomas Lee Abshier,51
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,U.S. Senate,,REP,Under Votes,103
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Pavel Goberman,3
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Al King,17
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Bruce Broussard,10
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,E. Bowerman,2
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Philip Petrie,3
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Thomas Lee Abshier,4
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,U.S. Senate,,REP,Under Votes,13
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Pavel Goberman,17
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Al King,395
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Bruce Broussard,98
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,E. Bowerman,48
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Philip Petrie,27
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Thomas Lee Abshier,98
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,U.S. Senate,,REP,Under Votes,333
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Pavel Goberman,1
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Al King,30
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Bruce Broussard,7
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,E. Bowerman,0
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Philip Petrie,5
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Thomas Lee Abshier,19
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,U.S. Senate,,REP,Under Votes,30
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Pavel Goberman,11
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Al King,72
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Bruce Broussard,18
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,E. Bowerman,14
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Philip Petrie,5
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Thomas Lee Abshier,6
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,U.S. Senate,,REP,Under Votes,97
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Pavel Goberman,24
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Al King,189
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Bruce Broussard,100
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,E. Bowerman,54
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Philip Petrie,25
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Thomas Lee Abshier,71
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Over Votes,2
+Lane,0039 2 FLORENCE 2,U.S. Senate,,REP,Under Votes,171
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Pavel Goberman,9
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Al King,114
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Bruce Broussard,38
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,E. Bowerman,34
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Philip Petrie,15
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Thomas Lee Abshier,58
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,U.S. Senate,,REP,Under Votes,52
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Pavel Goberman,2
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Al King,57
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Bruce Broussard,11
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,E. Bowerman,8
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Philip Petrie,4
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Thomas Lee Abshier,9
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,U.S. Senate,,REP,Under Votes,30
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Pavel Goberman,0
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Al King,9
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Bruce Broussard,8
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,E. Bowerman,2
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Philip Petrie,0
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Thomas Lee Abshier,8
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,U.S. Senate,,REP,Under Votes,13
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Pavel Goberman,18
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Al King,201
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Bruce Broussard,87
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,E. Bowerman,60
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Philip Petrie,17
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Thomas Lee Abshier,89
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Over Votes,0
+Lane,0008 2 CHESHIRE,U.S. Senate,,REP,Under Votes,167
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Pavel Goberman,6
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Al King,60
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Bruce Broussard,29
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,E. Bowerman,14
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Philip Petrie,13
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Thomas Lee Abshier,26
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Over Votes,1
+Lane,0027 1 SANTA CLARA 1,U.S. Senate,,REP,Under Votes,55
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Pavel Goberman,14
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Al King,278
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Bruce Broussard,59
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,E. Bowerman,44
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Philip Petrie,12
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Thomas Lee Abshier,73
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,U.S. Senate,,REP,Under Votes,236
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Pavel Goberman,8
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Al King,141
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Bruce Broussard,37
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,E. Bowerman,21
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Philip Petrie,6
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Thomas Lee Abshier,41
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Over Votes,0
+Lane,0014 0 GOSHEN,U.S. Senate,,REP,Under Votes,95
+Lane,0018 0 LORANE,U.S. Senate,,REP,Pavel Goberman,7
+Lane,0018 0 LORANE,U.S. Senate,,REP,Al King,104
+Lane,0018 0 LORANE,U.S. Senate,,REP,Bruce Broussard,21
+Lane,0018 0 LORANE,U.S. Senate,,REP,E. Bowerman,16
+Lane,0018 0 LORANE,U.S. Senate,,REP,Philip Petrie,5
+Lane,0018 0 LORANE,U.S. Senate,,REP,Thomas Lee Abshier,35
+Lane,0018 0 LORANE,U.S. Senate,,REP,Over Votes,0
+Lane,0018 0 LORANE,U.S. Senate,,REP,Under Votes,57
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Pavel Goberman,9
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Al King,100
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Bruce Broussard,36
+Lane,0003 4 BAILEY,U.S. Senate,,REP,E. Bowerman,24
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Philip Petrie,9
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Thomas Lee Abshier,40
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Over Votes,0
+Lane,0003 4 BAILEY,U.S. Senate,,REP,Under Votes,90
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Pavel Goberman,2
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Al King,77
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Bruce Broussard,11
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,E. Bowerman,9
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Philip Petrie,1
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Thomas Lee Abshier,28
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,U.S. Senate,,REP,Under Votes,60
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Pavel Goberman,15
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Al King,319
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Bruce Broussard,77
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,E. Bowerman,56
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Philip Petrie,21
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Thomas Lee Abshier,81
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,U.S. Senate,,REP,Under Votes,288
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Pavel Goberman,9
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Al King,130
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Bruce Broussard,48
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,E. Bowerman,24
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Philip Petrie,16
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Thomas Lee Abshier,57
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Over Votes,1
+Lane,0061 7 EUGENE 507,U.S. Senate,,REP,Under Votes,123
+Lane,0034 0 COBURG,U.S. Senate,,REP,Pavel Goberman,1
+Lane,0034 0 COBURG,U.S. Senate,,REP,Al King,30
+Lane,0034 0 COBURG,U.S. Senate,,REP,Bruce Broussard,9
+Lane,0034 0 COBURG,U.S. Senate,,REP,E. Bowerman,18
+Lane,0034 0 COBURG,U.S. Senate,,REP,Philip Petrie,6
+Lane,0034 0 COBURG,U.S. Senate,,REP,Thomas Lee Abshier,5
+Lane,0034 0 COBURG,U.S. Senate,,REP,Over Votes,0
+Lane,0034 0 COBURG,U.S. Senate,,REP,Under Votes,44
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Pavel Goberman,17
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Al King,134
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Bruce Broussard,90
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,E. Bowerman,39
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Philip Petrie,28
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Thomas Lee Abshier,53
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,U.S. Senate,,REP,Under Votes,130
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Pavel Goberman,6
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Al King,62
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Bruce Broussard,21
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,E. Bowerman,18
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Philip Petrie,3
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Thomas Lee Abshier,21
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Over Votes,1
+Lane,0051 5 EUGENE 235,U.S. Senate,,REP,Under Votes,93
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Pavel Goberman,2
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Al King,50
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Bruce Broussard,11
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,E. Bowerman,14
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Philip Petrie,1
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Thomas Lee Abshier,29
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Over Votes,0
+Lane,0016 5 GATEWAY,U.S. Senate,,REP,Under Votes,29
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Pavel Goberman,4
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Al King,78
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Bruce Broussard,23
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,E. Bowerman,8
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Philip Petrie,2
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Thomas Lee Abshier,25
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Over Votes,0
+Lane,0021 5 MARCOLA,U.S. Senate,,REP,Under Votes,35
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Pavel Goberman,4
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Al King,80
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Bruce Broussard,19
+Lane,0019 2 LOWELL,U.S. Senate,,REP,E. Bowerman,7
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Philip Petrie,8
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Thomas Lee Abshier,44
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Over Votes,1
+Lane,0019 2 LOWELL,U.S. Senate,,REP,Under Votes,47
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Pavel Goberman,9
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Al King,167
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Bruce Broussard,44
+Lane,0017 7 LATHAM,U.S. Senate,,REP,E. Bowerman,21
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Philip Petrie,5
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Thomas Lee Abshier,53
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Over Votes,0
+Lane,0017 7 LATHAM,U.S. Senate,,REP,Under Votes,120
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Pavel Goberman,3
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Al King,13
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Bruce Broussard,9
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,E. Bowerman,2
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Philip Petrie,1
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Thomas Lee Abshier,3
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,U.S. Senate,,REP,Under Votes,11
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Pavel Goberman,16
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Al King,147
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Bruce Broussard,37
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,E. Bowerman,25
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Philip Petrie,11
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Thomas Lee Abshier,55
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Over Votes,1
+Lane,0006 8 COAST FORK,U.S. Senate,,REP,Under Votes,88
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Pavel Goberman,18
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Al King,385
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Bruce Broussard,79
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,E. Bowerman,27
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Philip Petrie,19
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Thomas Lee Abshier,106
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,U.S. Senate,,REP,Under Votes,313
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Pavel Goberman,13
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Al King,167
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Bruce Broussard,48
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,E. Bowerman,17
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Philip Petrie,11
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Thomas Lee Abshier,31
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,U.S. Senate,,REP,Under Votes,133
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Pavel Goberman,18
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Al King,104
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Bruce Broussard,48
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,E. Bowerman,19
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Philip Petrie,11
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Thomas Lee Abshier,63
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Over Votes,0
+Lane,0009 0 ELMIRA,U.S. Senate,,REP,Under Votes,86
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Pavel Goberman,25
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Al King,173
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Bruce Broussard,56
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,E. Bowerman,22
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Philip Petrie,14
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Thomas Lee Abshier,80
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,U.S. Senate,,REP,Under Votes,169
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Pavel Goberman,19
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Al King,325
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Bruce Broussard,69
+Lane,0022 7 MOSBY,U.S. Senate,,REP,E. Bowerman,21
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Philip Petrie,17
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Thomas Lee Abshier,88
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Over Votes,0
+Lane,0022 7 MOSBY,U.S. Senate,,REP,Under Votes,185
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Pavel Goberman,5
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Al King,22
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Bruce Broussard,22
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,E. Bowerman,9
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Philip Petrie,2
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Thomas Lee Abshier,3
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,U.S. Senate,,REP,Under Votes,12
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Pavel Goberman,5
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Al King,38
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Bruce Broussard,15
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,E. Bowerman,6
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Philip Petrie,3
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Thomas Lee Abshier,28
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Over Votes,0
+Lane,0020 3 MAPLETON,U.S. Senate,,REP,Under Votes,35
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Al King,94
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Bruce Broussard,34
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,E. Bowerman,13
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Philip Petrie,14
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Thomas Lee Abshier,48
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Over Votes,0
+Lane,0001 1 ALVADORE,U.S. Senate,,REP,Under Votes,89
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Pavel Goberman,7
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Al King,47
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Bruce Broussard,20
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,E. Bowerman,5
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Philip Petrie,0
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Thomas Lee Abshier,16
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,U.S. Senate,,REP,Under Votes,63
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Pavel Goberman,0
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Al King,5
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Bruce Broussard,1
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,E. Bowerman,0
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Philip Petrie,1
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Thomas Lee Abshier,0
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,U.S. Senate,,REP,Under Votes,2
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Pavel Goberman,4
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Al King,68
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Bruce Broussard,22
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,E. Bowerman,18
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Philip Petrie,8
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Thomas Lee Abshier,21
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,U.S. Senate,,REP,Under Votes,24
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Pavel Goberman,6
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Al King,72
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Bruce Broussard,13
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,E. Bowerman,8
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Philip Petrie,6
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Thomas Lee Abshier,14
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,U.S. Senate,,REP,Under Votes,48
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Pavel Goberman,25
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Al King,190
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Bruce Broussard,48
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,E. Bowerman,35
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Philip Petrie,5
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Thomas Lee Abshier,70
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,U.S. Senate,,REP,Under Votes,189
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Pavel Goberman,7
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Al King,118
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Bruce Broussard,28
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,E. Bowerman,16
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Philip Petrie,3
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Thomas Lee Abshier,30
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,U.S. Senate,,REP,Under Votes,64
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Pavel Goberman,3
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Al King,37
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Bruce Broussard,8
+Lane,0007 9 CAMAS,U.S. Senate,,REP,E. Bowerman,2
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Philip Petrie,3
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Thomas Lee Abshier,5
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Over Votes,0
+Lane,0007 9 CAMAS,U.S. Senate,,REP,Under Votes,19
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Pavel Goberman,11
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Al King,164
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Bruce Broussard,34
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,E. Bowerman,8
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Philip Petrie,5
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Thomas Lee Abshier,22
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Over Votes,0
+Lane,0036 0 CRESWELL,U.S. Senate,,REP,Under Votes,61
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Pavel Goberman,3
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Al King,13
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Bruce Broussard,3
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,E. Bowerman,1
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Philip Petrie,0
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Thomas Lee Abshier,3
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,U.S. Senate,,REP,Under Votes,7
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Pavel Goberman,14
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Al King,141
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Bruce Broussard,30
+Lane,0032 3 WILKINS,U.S. Senate,,REP,E. Bowerman,32
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Philip Petrie,9
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Thomas Lee Abshier,51
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Over Votes,0
+Lane,0032 3 WILKINS,U.S. Senate,,REP,Under Votes,86
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Pavel Goberman,11
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Al King,111
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Bruce Broussard,45
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,E. Bowerman,39
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Philip Petrie,18
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Thomas Lee Abshier,68
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Over Votes,2
+Lane,0040 0 JUNCTION CITY,U.S. Senate,,REP,Under Votes,82
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Al King,145
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Bruce Broussard,55
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,E. Bowerman,27
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Philip Petrie,17
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Thomas Lee Abshier,37
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,U.S. Senate,,REP,Under Votes,126
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Pavel Goberman,5
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Al King,89
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Bruce Broussard,24
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,E. Bowerman,17
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Philip Petrie,2
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Thomas Lee Abshier,15
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,U.S. Senate,,REP,Under Votes,110
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Pavel Goberman,15
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Al King,120
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Bruce Broussard,22
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,E. Bowerman,7
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Philip Petrie,4
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Thomas Lee Abshier,40
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,U.S. Senate,,REP,Under Votes,42
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Pavel Goberman,22
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Al King,179
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Bruce Broussard,49
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,E. Bowerman,19
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Philip Petrie,15
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Thomas Lee Abshier,62
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Over Votes,2
+Lane,0078 6 SPRINGFIELD 206,U.S. Senate,,REP,Under Votes,108
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Pavel Goberman,16
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Al King,164
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Bruce Broussard,69
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,E. Bowerman,39
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Philip Petrie,21
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Thomas Lee Abshier,89
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,U.S. Senate,,REP,Under Votes,195
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Pavel Goberman,2
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Al King,10
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Bruce Broussard,4
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,E. Bowerman,5
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Philip Petrie,0
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Thomas Lee Abshier,2
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,U.S. Senate,,REP,Under Votes,27
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Pavel Goberman,19
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Al King,156
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Bruce Broussard,58
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,E. Bowerman,44
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Philip Petrie,13
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Thomas Lee Abshier,77
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,U.S. Senate,,REP,Under Votes,89
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Pavel Goberman,16
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Al King,181
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Bruce Broussard,58
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,E. Bowerman,28
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Philip Petrie,16
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Thomas Lee Abshier,82
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Over Votes,2
+Lane,0077 2 SPRINGFIELD 102,U.S. Senate,,REP,Under Votes,119
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Pavel Goberman,18
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Al King,95
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Bruce Broussard,43
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,E. Bowerman,23
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Philip Petrie,4
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Thomas Lee Abshier,56
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Over Votes,1
+Lane,0072 3 EUGENE 723,U.S. Senate,,REP,Under Votes,85
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Pavel Goberman,1
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Al King,11
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Bruce Broussard,1
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,E. Bowerman,1
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Philip Petrie,2
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Thomas Lee Abshier,2
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,U.S. Senate,,REP,Under Votes,7
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Al King,97
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Bruce Broussard,24
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,E. Bowerman,9
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Philip Petrie,4
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Thomas Lee Abshier,31
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Over Votes,1
+Lane,0083 8 SPRINGFIELD 608,U.S. Senate,,REP,Under Votes,58
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Pavel Goberman,10
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Al King,67
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Bruce Broussard,23
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,E. Bowerman,16
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Philip Petrie,4
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Thomas Lee Abshier,52
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,U.S. Senate,,REP,Under Votes,65
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Pavel Goberman,15
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Al King,233
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Bruce Broussard,102
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,E. Bowerman,43
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Philip Petrie,29
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Thomas Lee Abshier,119
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,U.S. Senate,,REP,Under Votes,196
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Pavel Goberman,0
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Al King,7
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Bruce Broussard,3
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,E. Bowerman,3
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Philip Petrie,1
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Thomas Lee Abshier,5
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,U.S. Senate,,REP,Under Votes,3
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Pavel Goberman,11
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Al King,169
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Bruce Broussard,45
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,E. Bowerman,36
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Philip Petrie,11
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Thomas Lee Abshier,74
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Over Votes,1
+Lane,0079 4 SPRINGFIELD 304,U.S. Senate,,REP,Under Votes,94
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Pavel Goberman,6
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Al King,14
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Bruce Broussard,13
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,E. Bowerman,4
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Philip Petrie,5
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Thomas Lee Abshier,13
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,U.S. Senate,,REP,Under Votes,19
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Pavel Goberman,14
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Al King,370
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Bruce Broussard,90
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,E. Bowerman,52
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Philip Petrie,27
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Thomas Lee Abshier,86
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Over Votes,2
+Lane,0063 3 EUGENE 523,U.S. Senate,,REP,Under Votes,335
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Pavel Goberman,19
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Al King,221
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Bruce Broussard,61
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,E. Bowerman,19
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Philip Petrie,12
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Thomas Lee Abshier,61
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,U.S. Senate,,REP,Under Votes,134
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Pavel Goberman,12
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Al King,205
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Bruce Broussard,42
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,E. Bowerman,32
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Philip Petrie,12
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Thomas Lee Abshier,69
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,U.S. Senate,,REP,Under Votes,179
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Pavel Goberman,16
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Al King,322
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Bruce Broussard,94
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,E. Bowerman,48
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Philip Petrie,17
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Thomas Lee Abshier,94
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,U.S. Senate,,REP,Under Votes,315
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Pavel Goberman,23
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Al King,221
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Bruce Broussard,53
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,E. Bowerman,22
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Philip Petrie,19
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Thomas Lee Abshier,100
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Over Votes,1
+Lane,0080 2 SPRINGFIELD 402,U.S. Senate,,REP,Under Votes,83
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Pavel Goberman,8
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Al King,50
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Bruce Broussard,19
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,E. Bowerman,12
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Philip Petrie,5
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Thomas Lee Abshier,14
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,U.S. Senate,,REP,Under Votes,42
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Pavel Goberman,15
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Al King,146
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Bruce Broussard,71
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,E. Bowerman,39
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Philip Petrie,12
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Thomas Lee Abshier,79
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Over Votes,1
+Lane,0066 3 EUGENE 623,U.S. Senate,,REP,Under Votes,163
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Pavel Goberman,6
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Al King,46
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Bruce Broussard,26
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,E. Bowerman,13
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Philip Petrie,5
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Thomas Lee Abshier,32
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,U.S. Senate,,REP,Under Votes,43
+Lane,0033 5 MCKENZIE,U.S. House,4,REP,Jim Feldkamp,488
+Lane,0033 5 MCKENZIE,U.S. House,4,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,U.S. House,4,REP,Under Votes,179
+Lane,0026 9 SALMON CREEK,U.S. House,4,REP,Jim Feldkamp,111
+Lane,0026 9 SALMON CREEK,U.S. House,4,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,U.S. House,4,REP,Under Votes,50
+Lane,0013 7 GLENADA,U.S. House,4,REP,Jim Feldkamp,146
+Lane,0013 7 GLENADA,U.S. House,4,REP,Over Votes,0
+Lane,0013 7 GLENADA,U.S. House,4,REP,Under Votes,61
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,REP,Jim Feldkamp,469
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,U.S. House,4,REP,Under Votes,143
+Lane,0010 2 FERNRIDGE,U.S. House,4,REP,Jim Feldkamp,228
+Lane,0010 2 FERNRIDGE,U.S. House,4,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,U.S. House,4,REP,Under Votes,75
+Lane,0002 3 ARMITAGE,U.S. House,4,REP,Jim Feldkamp,127
+Lane,0002 3 ARMITAGE,U.S. House,4,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,U.S. House,4,REP,Under Votes,43
+Lane,0030 0 SIUSLAW,U.S. House,4,REP,Jim Feldkamp,312
+Lane,0030 0 SIUSLAW,U.S. House,4,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,U.S. House,4,REP,Under Votes,100
+Lane,0052 7 EUGENE 237,U.S. House,4,REP,Jim Feldkamp,303
+Lane,0052 7 EUGENE 237,U.S. House,4,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,U.S. House,4,REP,Under Votes,165
+Lane,0004 5 BLACHLY,U.S. House,4,REP,Jim Feldkamp,118
+Lane,0004 5 BLACHLY,U.S. House,4,REP,Over Votes,0
+Lane,0004 5 BLACHLY,U.S. House,4,REP,Under Votes,45
+Lane,0063 3 EUGENE 523,U.S. House,4,REP,Jim Feldkamp,663
+Lane,0063 3 EUGENE 523,U.S. House,4,REP,Over Votes,3
+Lane,0063 3 EUGENE 523,U.S. House,4,REP,Under Votes,312
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,REP,Jim Feldkamp,584
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,U.S. House,4,REP,Under Votes,196
+Lane,0049 5 EUGENE 215,U.S. House,4,REP,Jim Feldkamp,344
+Lane,0049 5 EUGENE 215,U.S. House,4,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,U.S. House,4,REP,Under Votes,182
+Lane,0037 0 DUNES CITY,U.S. House,4,REP,Jim Feldkamp,175
+Lane,0037 0 DUNES CITY,U.S. House,4,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,U.S. House,4,REP,Under Votes,46
+Lane,0042 0 VENETA,U.S. House,4,REP,Jim Feldkamp,181
+Lane,0042 0 VENETA,U.S. House,4,REP,Over Votes,0
+Lane,0042 0 VENETA,U.S. House,4,REP,Under Votes,52
+Lane,0031 2 WALTERVILLE,U.S. House,4,REP,Jim Feldkamp,319
+Lane,0031 2 WALTERVILLE,U.S. House,4,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,U.S. House,4,REP,Under Votes,152
+Lane,0045 5 EUGENE 105,U.S. House,4,REP,Jim Feldkamp,39
+Lane,0045 5 EUGENE 105,U.S. House,4,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,U.S. House,4,REP,Under Votes,11
+Lane,0062 1 EUGENE 511,U.S. House,4,REP,Jim Feldkamp,691
+Lane,0062 1 EUGENE 511,U.S. House,4,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,U.S. House,4,REP,Under Votes,330
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,REP,Jim Feldkamp,52
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,U.S. House,4,REP,Under Votes,40
+Lane,0055 7 EUGENE 317,U.S. House,4,REP,Jim Feldkamp,128
+Lane,0055 7 EUGENE 317,U.S. House,4,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,U.S. House,4,REP,Under Votes,93
+Lane,0039 2 FLORENCE 2,U.S. House,4,REP,Jim Feldkamp,485
+Lane,0039 2 FLORENCE 2,U.S. House,4,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,U.S. House,4,REP,Under Votes,154
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,REP,Jim Feldkamp,242
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,U.S. House,4,REP,Under Votes,70
+Lane,0060 5 EUGENE 505,U.S. House,4,REP,Jim Feldkamp,95
+Lane,0060 5 EUGENE 505,U.S. House,4,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,U.S. House,4,REP,Under Votes,27
+Lane,0046 7 EUGENE 107,U.S. House,4,REP,Jim Feldkamp,30
+Lane,0046 7 EUGENE 107,U.S. House,4,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,U.S. House,4,REP,Under Votes,10
+Lane,0008 2 CHESHIRE,U.S. House,4,REP,Jim Feldkamp,443
+Lane,0008 2 CHESHIRE,U.S. House,4,REP,Over Votes,0
+Lane,0008 2 CHESHIRE,U.S. House,4,REP,Under Votes,196
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,REP,Jim Feldkamp,145
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,U.S. House,4,REP,Under Votes,59
+Lane,0058 5 EUGENE 435,U.S. House,4,REP,Jim Feldkamp,483
+Lane,0058 5 EUGENE 435,U.S. House,4,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,U.S. House,4,REP,Under Votes,230
+Lane,0014 0 GOSHEN,U.S. House,4,REP,Jim Feldkamp,242
+Lane,0014 0 GOSHEN,U.S. House,4,REP,Over Votes,0
+Lane,0014 0 GOSHEN,U.S. House,4,REP,Under Votes,106
+Lane,0018 0 LORANE,U.S. House,4,REP,Jim Feldkamp,165
+Lane,0018 0 LORANE,U.S. House,4,REP,Over Votes,0
+Lane,0018 0 LORANE,U.S. House,4,REP,Under Votes,80
+Lane,0003 4 BAILEY,U.S. House,4,REP,Jim Feldkamp,218
+Lane,0003 4 BAILEY,U.S. House,4,REP,Over Votes,0
+Lane,0003 4 BAILEY,U.S. House,4,REP,Under Votes,90
+Lane,0011 4 FOX HOLLOW,U.S. House,4,REP,Jim Feldkamp,126
+Lane,0011 4 FOX HOLLOW,U.S. House,4,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,U.S. House,4,REP,Under Votes,62
+Lane,0059 9 EUGENE 439,U.S. House,4,REP,Jim Feldkamp,607
+Lane,0059 9 EUGENE 439,U.S. House,4,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,U.S. House,4,REP,Under Votes,254
+Lane,0061 7 EUGENE 507,U.S. House,4,REP,Jim Feldkamp,287
+Lane,0061 7 EUGENE 507,U.S. House,4,REP,Over Votes,0
+Lane,0061 7 EUGENE 507,U.S. House,4,REP,Under Votes,118
+Lane,0034 0 COBURG,U.S. House,4,REP,Jim Feldkamp,66
+Lane,0034 0 COBURG,U.S. House,4,REP,Over Votes,0
+Lane,0034 0 COBURG,U.S. House,4,REP,Under Votes,46
+Lane,0038 1 FLORENCE 1,U.S. House,4,REP,Jim Feldkamp,369
+Lane,0038 1 FLORENCE 1,U.S. House,4,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,U.S. House,4,REP,Under Votes,120
+Lane,0051 5 EUGENE 235,U.S. House,4,REP,Jim Feldkamp,140
+Lane,0051 5 EUGENE 235,U.S. House,4,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,U.S. House,4,REP,Under Votes,87
+Lane,0016 5 GATEWAY,U.S. House,4,REP,Jim Feldkamp,102
+Lane,0016 5 GATEWAY,U.S. House,4,REP,Over Votes,0
+Lane,0016 5 GATEWAY,U.S. House,4,REP,Under Votes,34
+Lane,0021 5 MARCOLA,U.S. House,4,REP,Jim Feldkamp,123
+Lane,0021 5 MARCOLA,U.S. House,4,REP,Over Votes,0
+Lane,0021 5 MARCOLA,U.S. House,4,REP,Under Votes,55
+Lane,0019 2 LOWELL,U.S. House,4,REP,Jim Feldkamp,126
+Lane,0019 2 LOWELL,U.S. House,4,REP,Over Votes,0
+Lane,0019 2 LOWELL,U.S. House,4,REP,Under Votes,83
+Lane,0017 7 LATHAM,U.S. House,4,REP,Jim Feldkamp,281
+Lane,0017 7 LATHAM,U.S. House,4,REP,Over Votes,0
+Lane,0017 7 LATHAM,U.S. House,4,REP,Under Votes,137
+Lane,0048 7 EUGENE 117,U.S. House,4,REP,Jim Feldkamp,29
+Lane,0048 7 EUGENE 117,U.S. House,4,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,U.S. House,4,REP,Under Votes,12
+Lane,0006 8 COAST FORK,U.S. House,4,REP,Jim Feldkamp,268
+Lane,0006 8 COAST FORK,U.S. House,4,REP,Over Votes,0
+Lane,0006 8 COAST FORK,U.S. House,4,REP,Under Votes,108
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,REP,Jim Feldkamp,597
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,U.S. House,4,REP,Under Votes,345
+Lane,0050 3 EUGENE 223,U.S. House,4,REP,Jim Feldkamp,271
+Lane,0050 3 EUGENE 223,U.S. House,4,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,U.S. House,4,REP,Under Votes,144
+Lane,0009 0 ELMIRA,U.S. House,4,REP,Jim Feldkamp,258
+Lane,0009 0 ELMIRA,U.S. House,4,REP,Over Votes,0
+Lane,0009 0 ELMIRA,U.S. House,4,REP,Under Votes,88
+Lane,0025 6 RIVER ROAD,U.S. House,4,REP,Jim Feldkamp,360
+Lane,0025 6 RIVER ROAD,U.S. House,4,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,U.S. House,4,REP,Under Votes,175
+Lane,0022 7 MOSBY,U.S. House,4,REP,Jim Feldkamp,498
+Lane,0022 7 MOSBY,U.S. House,4,REP,Over Votes,0
+Lane,0022 7 MOSBY,U.S. House,4,REP,Under Votes,225
+Lane,0053 3 EUGENE 313,U.S. House,4,REP,Jim Feldkamp,57
+Lane,0053 3 EUGENE 313,U.S. House,4,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,U.S. House,4,REP,Under Votes,17
+Lane,0020 3 MAPLETON,U.S. House,4,REP,Jim Feldkamp,91
+Lane,0020 3 MAPLETON,U.S. House,4,REP,Over Votes,0
+Lane,0020 3 MAPLETON,U.S. House,4,REP,Under Votes,39
+Lane,0001 1 ALVADORE,U.S. House,4,REP,Jim Feldkamp,210
+Lane,0001 1 ALVADORE,U.S. House,4,REP,Over Votes,0
+Lane,0001 1 ALVADORE,U.S. House,4,REP,Under Votes,90
+Lane,0056 1 EUGENE 431,U.S. House,4,REP,Jim Feldkamp,111
+Lane,0056 1 EUGENE 431,U.S. House,4,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,U.S. House,4,REP,Under Votes,46
+Lane,0047 9 EUGENE 109,U.S. House,4,REP,Jim Feldkamp,5
+Lane,0047 9 EUGENE 109,U.S. House,4,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,U.S. House,4,REP,Under Votes,4
+Lane,0015 1 GROVEDALE,U.S. House,4,REP,Jim Feldkamp,115
+Lane,0015 1 GROVEDALE,U.S. House,4,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,U.S. House,4,REP,Under Votes,49
+Lane,0054 5 EUGENE 315,U.S. House,4,REP,Jim Feldkamp,106
+Lane,0054 5 EUGENE 315,U.S. House,4,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,U.S. House,4,REP,Under Votes,61
+Lane,0043 1 EUGENE 101,U.S. House,4,REP,Jim Feldkamp,366
+Lane,0043 1 EUGENE 101,U.S. House,4,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,U.S. House,4,REP,Under Votes,190
+Lane,0005 7 BLUE RIVER,U.S. House,4,REP,Jim Feldkamp,199
+Lane,0005 7 BLUE RIVER,U.S. House,4,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,U.S. House,4,REP,Under Votes,65
+Lane,0007 9 CAMAS,U.S. House,4,REP,Jim Feldkamp,48
+Lane,0007 9 CAMAS,U.S. House,4,REP,Over Votes,0
+Lane,0007 9 CAMAS,U.S. House,4,REP,Under Votes,30
+Lane,0036 0 CRESWELL,U.S. House,4,REP,Jim Feldkamp,217
+Lane,0036 0 CRESWELL,U.S. House,4,REP,Over Votes,0
+Lane,0036 0 CRESWELL,U.S. House,4,REP,Under Votes,88
+Lane,0012 6 GARDEN WAY,U.S. House,4,REP,Jim Feldkamp,22
+Lane,0012 6 GARDEN WAY,U.S. House,4,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,U.S. House,4,REP,Under Votes,10
+Lane,0032 3 WILKINS,U.S. House,4,REP,Jim Feldkamp,255
+Lane,0032 3 WILKINS,U.S. House,4,REP,Over Votes,0
+Lane,0032 3 WILKINS,U.S. House,4,REP,Under Votes,103
+Lane,0040 0 JUNCTION CITY,U.S. House,4,REP,Jim Feldkamp,284
+Lane,0040 0 JUNCTION CITY,U.S. House,4,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,U.S. House,4,REP,Under Votes,87
+Lane,0057 3 EUGENE 433,U.S. House,4,REP,Jim Feldkamp,271
+Lane,0057 3 EUGENE 433,U.S. House,4,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,U.S. House,4,REP,Under Votes,144
+Lane,0044 3 EUGENE 103,U.S. House,4,REP,Jim Feldkamp,163
+Lane,0044 3 EUGENE 103,U.S. House,4,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,U.S. House,4,REP,Under Votes,99
+Lane,0041 0 OAKRIDGE,U.S. House,4,REP,Jim Feldkamp,180
+Lane,0041 0 OAKRIDGE,U.S. House,4,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,U.S. House,4,REP,Under Votes,65
+Lane,0033 5 MCKENZIE,Secretary of State,,REP,Fred Granum,236
+Lane,0033 5 MCKENZIE,Secretary of State,,REP,Betsy L. Close,303
+Lane,0033 5 MCKENZIE,Secretary of State,,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,Secretary of State,,REP,Under Votes,138
+Lane,0026 9 SALMON CREEK,Secretary of State,,REP,Fred Granum,50
+Lane,0026 9 SALMON CREEK,Secretary of State,,REP,Betsy L. Close,73
+Lane,0026 9 SALMON CREEK,Secretary of State,,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,Secretary of State,,REP,Under Votes,41
+Lane,0013 7 GLENADA,Secretary of State,,REP,Fred Granum,87
+Lane,0013 7 GLENADA,Secretary of State,,REP,Betsy L. Close,80
+Lane,0013 7 GLENADA,Secretary of State,,REP,Over Votes,0
+Lane,0013 7 GLENADA,Secretary of State,,REP,Under Votes,41
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,REP,Fred Granum,244
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,REP,Betsy L. Close,254
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,REP,Over Votes,1
+Lane,0028 4 SANTA CLARA 4,Secretary of State,,REP,Under Votes,116
+Lane,0010 2 FERNRIDGE,Secretary of State,,REP,Fred Granum,136
+Lane,0010 2 FERNRIDGE,Secretary of State,,REP,Betsy L. Close,116
+Lane,0010 2 FERNRIDGE,Secretary of State,,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,Secretary of State,,REP,Under Votes,53
+Lane,0002 3 ARMITAGE,Secretary of State,,REP,Fred Granum,84
+Lane,0002 3 ARMITAGE,Secretary of State,,REP,Betsy L. Close,66
+Lane,0002 3 ARMITAGE,Secretary of State,,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,Secretary of State,,REP,Under Votes,24
+Lane,0030 0 SIUSLAW,Secretary of State,,REP,Fred Granum,160
+Lane,0030 0 SIUSLAW,Secretary of State,,REP,Betsy L. Close,161
+Lane,0030 0 SIUSLAW,Secretary of State,,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,Secretary of State,,REP,Under Votes,98
+Lane,0052 7 EUGENE 237,Secretary of State,,REP,Fred Granum,186
+Lane,0052 7 EUGENE 237,Secretary of State,,REP,Betsy L. Close,140
+Lane,0052 7 EUGENE 237,Secretary of State,,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,Secretary of State,,REP,Under Votes,149
+Lane,0004 5 BLACHLY,Secretary of State,,REP,Fred Granum,69
+Lane,0004 5 BLACHLY,Secretary of State,,REP,Betsy L. Close,63
+Lane,0004 5 BLACHLY,Secretary of State,,REP,Over Votes,0
+Lane,0004 5 BLACHLY,Secretary of State,,REP,Under Votes,32
+Lane,0063 3 EUGENE 523,Secretary of State,,REP,Fred Granum,402
+Lane,0063 3 EUGENE 523,Secretary of State,,REP,Betsy L. Close,309
+Lane,0063 3 EUGENE 523,Secretary of State,,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,Secretary of State,,REP,Under Votes,270
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,REP,Fred Granum,337
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,REP,Betsy L. Close,283
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,REP,Over Votes,1
+Lane,0035 0 COTTAGE GROVE,Secretary of State,,REP,Under Votes,164
+Lane,0049 5 EUGENE 215,Secretary of State,,REP,Fred Granum,172
+Lane,0049 5 EUGENE 215,Secretary of State,,REP,Betsy L. Close,207
+Lane,0049 5 EUGENE 215,Secretary of State,,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,Secretary of State,,REP,Under Votes,152
+Lane,0037 0 DUNES CITY,Secretary of State,,REP,Fred Granum,91
+Lane,0037 0 DUNES CITY,Secretary of State,,REP,Betsy L. Close,92
+Lane,0037 0 DUNES CITY,Secretary of State,,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,Secretary of State,,REP,Under Votes,39
+Lane,0042 0 VENETA,Secretary of State,,REP,Fred Granum,116
+Lane,0042 0 VENETA,Secretary of State,,REP,Betsy L. Close,91
+Lane,0042 0 VENETA,Secretary of State,,REP,Over Votes,0
+Lane,0042 0 VENETA,Secretary of State,,REP,Under Votes,33
+Lane,0031 2 WALTERVILLE,Secretary of State,,REP,Fred Granum,200
+Lane,0031 2 WALTERVILLE,Secretary of State,,REP,Betsy L. Close,188
+Lane,0031 2 WALTERVILLE,Secretary of State,,REP,Over Votes,1
+Lane,0031 2 WALTERVILLE,Secretary of State,,REP,Under Votes,89
+Lane,0045 5 EUGENE 105,Secretary of State,,REP,Fred Granum,20
+Lane,0045 5 EUGENE 105,Secretary of State,,REP,Betsy L. Close,21
+Lane,0045 5 EUGENE 105,Secretary of State,,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,Secretary of State,,REP,Under Votes,11
+Lane,0062 1 EUGENE 511,Secretary of State,,REP,Fred Granum,436
+Lane,0062 1 EUGENE 511,Secretary of State,,REP,Betsy L. Close,278
+Lane,0062 1 EUGENE 511,Secretary of State,,REP,Over Votes,1
+Lane,0062 1 EUGENE 511,Secretary of State,,REP,Under Votes,306
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,REP,Fred Granum,35
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,REP,Betsy L. Close,25
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,REP,Over Votes,1
+Lane,0024 2 PLEASANT HILL 2,Secretary of State,,REP,Under Votes,31
+Lane,0055 7 EUGENE 317,Secretary of State,,REP,Fred Granum,80
+Lane,0055 7 EUGENE 317,Secretary of State,,REP,Betsy L. Close,53
+Lane,0055 7 EUGENE 317,Secretary of State,,REP,Over Votes,1
+Lane,0055 7 EUGENE 317,Secretary of State,,REP,Under Votes,89
+Lane,0039 2 FLORENCE 2,Secretary of State,,REP,Fred Granum,243
+Lane,0039 2 FLORENCE 2,Secretary of State,,REP,Betsy L. Close,252
+Lane,0039 2 FLORENCE 2,Secretary of State,,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,Secretary of State,,REP,Under Votes,151
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,REP,Fred Granum,132
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,REP,Betsy L. Close,137
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,Secretary of State,,REP,Under Votes,49
+Lane,0060 5 EUGENE 505,Secretary of State,,REP,Fred Granum,59
+Lane,0060 5 EUGENE 505,Secretary of State,,REP,Betsy L. Close,41
+Lane,0060 5 EUGENE 505,Secretary of State,,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,Secretary of State,,REP,Under Votes,22
+Lane,0046 7 EUGENE 107,Secretary of State,,REP,Fred Granum,16
+Lane,0046 7 EUGENE 107,Secretary of State,,REP,Betsy L. Close,13
+Lane,0046 7 EUGENE 107,Secretary of State,,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,Secretary of State,,REP,Under Votes,11
+Lane,0008 2 CHESHIRE,Secretary of State,,REP,Fred Granum,247
+Lane,0008 2 CHESHIRE,Secretary of State,,REP,Betsy L. Close,254
+Lane,0008 2 CHESHIRE,Secretary of State,,REP,Over Votes,1
+Lane,0008 2 CHESHIRE,Secretary of State,,REP,Under Votes,136
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,REP,Fred Granum,80
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,REP,Betsy L. Close,78
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,Secretary of State,,REP,Under Votes,47
+Lane,0058 5 EUGENE 435,Secretary of State,,REP,Fred Granum,284
+Lane,0058 5 EUGENE 435,Secretary of State,,REP,Betsy L. Close,232
+Lane,0058 5 EUGENE 435,Secretary of State,,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,Secretary of State,,REP,Under Votes,206
+Lane,0014 0 GOSHEN,Secretary of State,,REP,Fred Granum,144
+Lane,0014 0 GOSHEN,Secretary of State,,REP,Betsy L. Close,130
+Lane,0014 0 GOSHEN,Secretary of State,,REP,Over Votes,0
+Lane,0014 0 GOSHEN,Secretary of State,,REP,Under Votes,77
+Lane,0018 0 LORANE,Secretary of State,,REP,Fred Granum,84
+Lane,0018 0 LORANE,Secretary of State,,REP,Betsy L. Close,116
+Lane,0018 0 LORANE,Secretary of State,,REP,Over Votes,0
+Lane,0018 0 LORANE,Secretary of State,,REP,Under Votes,45
+Lane,0003 4 BAILEY,Secretary of State,,REP,Fred Granum,133
+Lane,0003 4 BAILEY,Secretary of State,,REP,Betsy L. Close,112
+Lane,0003 4 BAILEY,Secretary of State,,REP,Over Votes,0
+Lane,0003 4 BAILEY,Secretary of State,,REP,Under Votes,68
+Lane,0011 4 FOX HOLLOW,Secretary of State,,REP,Fred Granum,80
+Lane,0011 4 FOX HOLLOW,Secretary of State,,REP,Betsy L. Close,63
+Lane,0011 4 FOX HOLLOW,Secretary of State,,REP,Over Votes,1
+Lane,0011 4 FOX HOLLOW,Secretary of State,,REP,Under Votes,45
+Lane,0059 9 EUGENE 439,Secretary of State,,REP,Fred Granum,338
+Lane,0059 9 EUGENE 439,Secretary of State,,REP,Betsy L. Close,277
+Lane,0059 9 EUGENE 439,Secretary of State,,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,Secretary of State,,REP,Under Votes,247
+Lane,0061 7 EUGENE 507,Secretary of State,,REP,Fred Granum,157
+Lane,0061 7 EUGENE 507,Secretary of State,,REP,Betsy L. Close,149
+Lane,0061 7 EUGENE 507,Secretary of State,,REP,Over Votes,1
+Lane,0061 7 EUGENE 507,Secretary of State,,REP,Under Votes,101
+Lane,0034 0 COBURG,Secretary of State,,REP,Fred Granum,42
+Lane,0034 0 COBURG,Secretary of State,,REP,Betsy L. Close,39
+Lane,0034 0 COBURG,Secretary of State,,REP,Over Votes,0
+Lane,0034 0 COBURG,Secretary of State,,REP,Under Votes,32
+Lane,0038 1 FLORENCE 1,Secretary of State,,REP,Fred Granum,178
+Lane,0038 1 FLORENCE 1,Secretary of State,,REP,Betsy L. Close,214
+Lane,0038 1 FLORENCE 1,Secretary of State,,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,Secretary of State,,REP,Under Votes,103
+Lane,0051 5 EUGENE 235,Secretary of State,,REP,Fred Granum,79
+Lane,0051 5 EUGENE 235,Secretary of State,,REP,Betsy L. Close,71
+Lane,0051 5 EUGENE 235,Secretary of State,,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,Secretary of State,,REP,Under Votes,80
+Lane,0016 5 GATEWAY,Secretary of State,,REP,Fred Granum,66
+Lane,0016 5 GATEWAY,Secretary of State,,REP,Betsy L. Close,48
+Lane,0016 5 GATEWAY,Secretary of State,,REP,Over Votes,0
+Lane,0016 5 GATEWAY,Secretary of State,,REP,Under Votes,24
+Lane,0021 5 MARCOLA,Secretary of State,,REP,Fred Granum,76
+Lane,0021 5 MARCOLA,Secretary of State,,REP,Betsy L. Close,69
+Lane,0021 5 MARCOLA,Secretary of State,,REP,Over Votes,0
+Lane,0021 5 MARCOLA,Secretary of State,,REP,Under Votes,35
+Lane,0019 2 LOWELL,Secretary of State,,REP,Fred Granum,82
+Lane,0019 2 LOWELL,Secretary of State,,REP,Betsy L. Close,72
+Lane,0019 2 LOWELL,Secretary of State,,REP,Over Votes,0
+Lane,0019 2 LOWELL,Secretary of State,,REP,Under Votes,56
+Lane,0017 7 LATHAM,Secretary of State,,REP,Fred Granum,182
+Lane,0017 7 LATHAM,Secretary of State,,REP,Betsy L. Close,143
+Lane,0017 7 LATHAM,Secretary of State,,REP,Over Votes,1
+Lane,0017 7 LATHAM,Secretary of State,,REP,Under Votes,92
+Lane,0048 7 EUGENE 117,Secretary of State,,REP,Fred Granum,12
+Lane,0048 7 EUGENE 117,Secretary of State,,REP,Betsy L. Close,21
+Lane,0048 7 EUGENE 117,Secretary of State,,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,Secretary of State,,REP,Under Votes,8
+Lane,0006 8 COAST FORK,Secretary of State,,REP,Fred Granum,160
+Lane,0006 8 COAST FORK,Secretary of State,,REP,Betsy L. Close,138
+Lane,0006 8 COAST FORK,Secretary of State,,REP,Over Votes,0
+Lane,0006 8 COAST FORK,Secretary of State,,REP,Under Votes,81
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,REP,Fred Granum,350
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,REP,Betsy L. Close,299
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,Secretary of State,,REP,Under Votes,302
+Lane,0050 3 EUGENE 223,Secretary of State,,REP,Fred Granum,171
+Lane,0050 3 EUGENE 223,Secretary of State,,REP,Betsy L. Close,131
+Lane,0050 3 EUGENE 223,Secretary of State,,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,Secretary of State,,REP,Under Votes,119
+Lane,0009 0 ELMIRA,Secretary of State,,REP,Fred Granum,139
+Lane,0009 0 ELMIRA,Secretary of State,,REP,Betsy L. Close,144
+Lane,0009 0 ELMIRA,Secretary of State,,REP,Over Votes,0
+Lane,0009 0 ELMIRA,Secretary of State,,REP,Under Votes,65
+Lane,0025 6 RIVER ROAD,Secretary of State,,REP,Fred Granum,192
+Lane,0025 6 RIVER ROAD,Secretary of State,,REP,Betsy L. Close,209
+Lane,0025 6 RIVER ROAD,Secretary of State,,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,Secretary of State,,REP,Under Votes,138
+Lane,0022 7 MOSBY,Secretary of State,,REP,Fred Granum,318
+Lane,0022 7 MOSBY,Secretary of State,,REP,Betsy L. Close,240
+Lane,0022 7 MOSBY,Secretary of State,,REP,Over Votes,0
+Lane,0022 7 MOSBY,Secretary of State,,REP,Under Votes,171
+Lane,0053 3 EUGENE 313,Secretary of State,,REP,Fred Granum,35
+Lane,0053 3 EUGENE 313,Secretary of State,,REP,Betsy L. Close,27
+Lane,0053 3 EUGENE 313,Secretary of State,,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,Secretary of State,,REP,Under Votes,14
+Lane,0020 3 MAPLETON,Secretary of State,,REP,Fred Granum,59
+Lane,0020 3 MAPLETON,Secretary of State,,REP,Betsy L. Close,46
+Lane,0020 3 MAPLETON,Secretary of State,,REP,Over Votes,0
+Lane,0020 3 MAPLETON,Secretary of State,,REP,Under Votes,24
+Lane,0001 1 ALVADORE,Secretary of State,,REP,Fred Granum,143
+Lane,0001 1 ALVADORE,Secretary of State,,REP,Betsy L. Close,91
+Lane,0001 1 ALVADORE,Secretary of State,,REP,Over Votes,0
+Lane,0001 1 ALVADORE,Secretary of State,,REP,Under Votes,71
+Lane,0056 1 EUGENE 431,Secretary of State,,REP,Fred Granum,59
+Lane,0056 1 EUGENE 431,Secretary of State,,REP,Betsy L. Close,53
+Lane,0056 1 EUGENE 431,Secretary of State,,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,Secretary of State,,REP,Under Votes,47
+Lane,0047 9 EUGENE 109,Secretary of State,,REP,Fred Granum,3
+Lane,0047 9 EUGENE 109,Secretary of State,,REP,Betsy L. Close,2
+Lane,0047 9 EUGENE 109,Secretary of State,,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,Secretary of State,,REP,Under Votes,4
+Lane,0015 1 GROVEDALE,Secretary of State,,REP,Fred Granum,52
+Lane,0015 1 GROVEDALE,Secretary of State,,REP,Betsy L. Close,83
+Lane,0015 1 GROVEDALE,Secretary of State,,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,Secretary of State,,REP,Under Votes,31
+Lane,0054 5 EUGENE 315,Secretary of State,,REP,Fred Granum,81
+Lane,0054 5 EUGENE 315,Secretary of State,,REP,Betsy L. Close,46
+Lane,0054 5 EUGENE 315,Secretary of State,,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,Secretary of State,,REP,Under Votes,42
+Lane,0043 1 EUGENE 101,Secretary of State,,REP,Fred Granum,213
+Lane,0043 1 EUGENE 101,Secretary of State,,REP,Betsy L. Close,196
+Lane,0043 1 EUGENE 101,Secretary of State,,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,Secretary of State,,REP,Under Votes,156
+Lane,0005 7 BLUE RIVER,Secretary of State,,REP,Fred Granum,97
+Lane,0005 7 BLUE RIVER,Secretary of State,,REP,Betsy L. Close,111
+Lane,0005 7 BLUE RIVER,Secretary of State,,REP,Over Votes,1
+Lane,0005 7 BLUE RIVER,Secretary of State,,REP,Under Votes,57
+Lane,0007 9 CAMAS,Secretary of State,,REP,Fred Granum,34
+Lane,0007 9 CAMAS,Secretary of State,,REP,Betsy L. Close,24
+Lane,0007 9 CAMAS,Secretary of State,,REP,Over Votes,0
+Lane,0007 9 CAMAS,Secretary of State,,REP,Under Votes,20
+Lane,0036 0 CRESWELL,Secretary of State,,REP,Fred Granum,121
+Lane,0036 0 CRESWELL,Secretary of State,,REP,Betsy L. Close,112
+Lane,0036 0 CRESWELL,Secretary of State,,REP,Over Votes,0
+Lane,0036 0 CRESWELL,Secretary of State,,REP,Under Votes,71
+Lane,0012 6 GARDEN WAY,Secretary of State,,REP,Fred Granum,13
+Lane,0012 6 GARDEN WAY,Secretary of State,,REP,Betsy L. Close,13
+Lane,0012 6 GARDEN WAY,Secretary of State,,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,Secretary of State,,REP,Under Votes,7
+Lane,0032 3 WILKINS,Secretary of State,,REP,Fred Granum,181
+Lane,0032 3 WILKINS,Secretary of State,,REP,Betsy L. Close,114
+Lane,0032 3 WILKINS,Secretary of State,,REP,Over Votes,0
+Lane,0032 3 WILKINS,Secretary of State,,REP,Under Votes,68
+Lane,0040 0 JUNCTION CITY,Secretary of State,,REP,Fred Granum,122
+Lane,0040 0 JUNCTION CITY,Secretary of State,,REP,Betsy L. Close,188
+Lane,0040 0 JUNCTION CITY,Secretary of State,,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,Secretary of State,,REP,Under Votes,67
+Lane,0057 3 EUGENE 433,Secretary of State,,REP,Fred Granum,182
+Lane,0057 3 EUGENE 433,Secretary of State,,REP,Betsy L. Close,122
+Lane,0057 3 EUGENE 433,Secretary of State,,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,Secretary of State,,REP,Under Votes,116
+Lane,0044 3 EUGENE 103,Secretary of State,,REP,Fred Granum,85
+Lane,0044 3 EUGENE 103,Secretary of State,,REP,Betsy L. Close,77
+Lane,0044 3 EUGENE 103,Secretary of State,,REP,Over Votes,1
+Lane,0044 3 EUGENE 103,Secretary of State,,REP,Under Votes,99
+Lane,0041 0 OAKRIDGE,Secretary of State,,REP,Fred Granum,85
+Lane,0041 0 OAKRIDGE,Secretary of State,,REP,Betsy L. Close,111
+Lane,0041 0 OAKRIDGE,Secretary of State,,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,Secretary of State,,REP,Under Votes,51
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,REP,Jim Feldkamp,336
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,U.S. House,4,REP,Under Votes,115
+Lane,0064 3 EUGENE 613,U.S. House,4,REP,Jim Feldkamp,408
+Lane,0064 3 EUGENE 613,U.S. House,4,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,U.S. House,4,REP,Under Votes,184
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,REP,Jim Feldkamp,167
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,U.S. House,4,REP,Under Votes,69
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,REP,Jim Feldkamp,341
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,U.S. House,4,REP,Under Votes,115
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,REP,Jim Feldkamp,377
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,U.S. House,4,REP,Under Votes,125
+Lane,0072 3 EUGENE 723,U.S. House,4,REP,Jim Feldkamp,226
+Lane,0072 3 EUGENE 723,U.S. House,4,REP,Over Votes,0
+Lane,0072 3 EUGENE 723,U.S. House,4,REP,Under Votes,93
+Lane,0070 7 EUGENE 717,U.S. House,4,REP,Jim Feldkamp,18
+Lane,0070 7 EUGENE 717,U.S. House,4,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,U.S. House,4,REP,Under Votes,8
+Lane,0074 5 EUGENE 805,U.S. House,4,REP,Jim Feldkamp,162
+Lane,0074 5 EUGENE 805,U.S. House,4,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,U.S. House,4,REP,Under Votes,74
+Lane,0065 7 EUGENE 617,U.S. House,4,REP,Jim Feldkamp,539
+Lane,0065 7 EUGENE 617,U.S. House,4,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,U.S. House,4,REP,Under Votes,200
+Lane,0069 5 EUGENE 715,U.S. House,4,REP,Jim Feldkamp,16
+Lane,0069 5 EUGENE 715,U.S. House,4,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,U.S. House,4,REP,Under Votes,5
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,REP,Jim Feldkamp,313
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,U.S. House,4,REP,Under Votes,123
+Lane,0067 1 EUGENE 711,U.S. House,4,REP,Jim Feldkamp,58
+Lane,0067 1 EUGENE 711,U.S. House,4,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,U.S. House,4,REP,Under Votes,16
+Lane,0071 9 EUGENE 719,U.S. House,4,REP,Jim Feldkamp,22
+Lane,0071 9 EUGENE 719,U.S. House,4,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,U.S. House,4,REP,Under Votes,28
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,REP,Jim Feldkamp,382
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,U.S. House,4,REP,Under Votes,143
+Lane,0068 3 EUGENE 713,U.S. House,4,REP,Jim Feldkamp,378
+Lane,0068 3 EUGENE 713,U.S. House,4,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,U.S. House,4,REP,Under Votes,175
+Lane,0075 7 EUGENE 807,U.S. House,4,REP,Jim Feldkamp,609
+Lane,0075 7 EUGENE 807,U.S. House,4,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,U.S. House,4,REP,Under Votes,301
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,REP,Jim Feldkamp,403
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,U.S. House,4,REP,Under Votes,115
+Lane,0073 3 EUGENE 803,U.S. House,4,REP,Jim Feldkamp,99
+Lane,0073 3 EUGENE 803,U.S. House,4,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,U.S. House,4,REP,Under Votes,51
+Lane,0066 3 EUGENE 623,U.S. House,4,REP,Jim Feldkamp,360
+Lane,0066 3 EUGENE 623,U.S. House,4,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,U.S. House,4,REP,Under Votes,162
+Lane,0076 9 EUGENE 809,U.S. House,4,REP,Jim Feldkamp,114
+Lane,0076 9 EUGENE 809,U.S. House,4,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,U.S. House,4,REP,Under Votes,56
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,REP,Fred Granum,159
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,REP,Betsy L. Close,211
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,Secretary of State,,REP,Under Votes,86
+Lane,0064 3 EUGENE 613,Secretary of State,,REP,Fred Granum,218
+Lane,0064 3 EUGENE 613,Secretary of State,,REP,Betsy L. Close,218
+Lane,0064 3 EUGENE 613,Secretary of State,,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,Secretary of State,,REP,Under Votes,151
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,REP,Fred Granum,85
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,REP,Betsy L. Close,97
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,Secretary of State,,REP,Under Votes,55
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,REP,Fred Granum,176
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,REP,Betsy L. Close,196
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,Secretary of State,,REP,Under Votes,85
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,REP,Fred Granum,189
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,REP,Betsy L. Close,222
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,Secretary of State,,REP,Under Votes,94
+Lane,0072 3 EUGENE 723,Secretary of State,,REP,Fred Granum,119
+Lane,0072 3 EUGENE 723,Secretary of State,,REP,Betsy L. Close,140
+Lane,0072 3 EUGENE 723,Secretary of State,,REP,Over Votes,1
+Lane,0072 3 EUGENE 723,Secretary of State,,REP,Under Votes,65
+Lane,0070 7 EUGENE 717,Secretary of State,,REP,Fred Granum,8
+Lane,0070 7 EUGENE 717,Secretary of State,,REP,Betsy L. Close,10
+Lane,0070 7 EUGENE 717,Secretary of State,,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,Secretary of State,,REP,Under Votes,8
+Lane,0074 5 EUGENE 805,Secretary of State,,REP,Fred Granum,74
+Lane,0074 5 EUGENE 805,Secretary of State,,REP,Betsy L. Close,110
+Lane,0074 5 EUGENE 805,Secretary of State,,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,Secretary of State,,REP,Under Votes,58
+Lane,0065 7 EUGENE 617,Secretary of State,,REP,Fred Granum,293
+Lane,0065 7 EUGENE 617,Secretary of State,,REP,Betsy L. Close,301
+Lane,0065 7 EUGENE 617,Secretary of State,,REP,Over Votes,1
+Lane,0065 7 EUGENE 617,Secretary of State,,REP,Under Votes,147
+Lane,0069 5 EUGENE 715,Secretary of State,,REP,Fred Granum,9
+Lane,0069 5 EUGENE 715,Secretary of State,,REP,Betsy L. Close,10
+Lane,0069 5 EUGENE 715,Secretary of State,,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,Secretary of State,,REP,Under Votes,3
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,REP,Fred Granum,160
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,REP,Betsy L. Close,195
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,Secretary of State,,REP,Under Votes,91
+Lane,0067 1 EUGENE 711,Secretary of State,,REP,Fred Granum,34
+Lane,0067 1 EUGENE 711,Secretary of State,,REP,Betsy L. Close,27
+Lane,0067 1 EUGENE 711,Secretary of State,,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,Secretary of State,,REP,Under Votes,14
+Lane,0071 9 EUGENE 719,Secretary of State,,REP,Fred Granum,15
+Lane,0071 9 EUGENE 719,Secretary of State,,REP,Betsy L. Close,14
+Lane,0071 9 EUGENE 719,Secretary of State,,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,Secretary of State,,REP,Under Votes,21
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,REP,Fred Granum,203
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,REP,Betsy L. Close,195
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,Secretary of State,,REP,Under Votes,129
+Lane,0068 3 EUGENE 713,Secretary of State,,REP,Fred Granum,225
+Lane,0068 3 EUGENE 713,Secretary of State,,REP,Betsy L. Close,189
+Lane,0068 3 EUGENE 713,Secretary of State,,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,Secretary of State,,REP,Under Votes,142
+Lane,0075 7 EUGENE 807,Secretary of State,,REP,Fred Granum,344
+Lane,0075 7 EUGENE 807,Secretary of State,,REP,Betsy L. Close,321
+Lane,0075 7 EUGENE 807,Secretary of State,,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,Secretary of State,,REP,Under Votes,248
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,REP,Fred Granum,212
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,REP,Betsy L. Close,240
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,Secretary of State,,REP,Under Votes,75
+Lane,0073 3 EUGENE 803,Secretary of State,,REP,Fred Granum,74
+Lane,0073 3 EUGENE 803,Secretary of State,,REP,Betsy L. Close,51
+Lane,0073 3 EUGENE 803,Secretary of State,,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,Secretary of State,,REP,Under Votes,27
+Lane,0066 3 EUGENE 623,Secretary of State,,REP,Fred Granum,177
+Lane,0066 3 EUGENE 623,Secretary of State,,REP,Betsy L. Close,214
+Lane,0066 3 EUGENE 623,Secretary of State,,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,Secretary of State,,REP,Under Votes,139
+Lane,0076 9 EUGENE 809,Secretary of State,,REP,Fred Granum,61
+Lane,0076 9 EUGENE 809,Secretary of State,,REP,Betsy L. Close,69
+Lane,0076 9 EUGENE 809,Secretary of State,,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,Secretary of State,,REP,Under Votes,41
+Lane,0033 5 MCKENZIE,State Treasurer,,REP,Jeff Caton,463
+Lane,0033 5 MCKENZIE,State Treasurer,,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,State Treasurer,,REP,Under Votes,213
+Lane,0026 9 SALMON CREEK,State Treasurer,,REP,Jeff Caton,103
+Lane,0026 9 SALMON CREEK,State Treasurer,,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,State Treasurer,,REP,Under Votes,59
+Lane,0013 7 GLENADA,State Treasurer,,REP,Jeff Caton,147
+Lane,0013 7 GLENADA,State Treasurer,,REP,Over Votes,0
+Lane,0013 7 GLENADA,State Treasurer,,REP,Under Votes,62
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,REP,Jeff Caton,458
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,State Treasurer,,REP,Under Votes,159
+Lane,0010 2 FERNRIDGE,State Treasurer,,REP,Jeff Caton,211
+Lane,0010 2 FERNRIDGE,State Treasurer,,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,State Treasurer,,REP,Under Votes,92
+Lane,0002 3 ARMITAGE,State Treasurer,,REP,Jeff Caton,107
+Lane,0002 3 ARMITAGE,State Treasurer,,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,State Treasurer,,REP,Under Votes,68
+Lane,0030 0 SIUSLAW,State Treasurer,,REP,Jeff Caton,293
+Lane,0030 0 SIUSLAW,State Treasurer,,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,State Treasurer,,REP,Under Votes,125
+Lane,0052 7 EUGENE 237,State Treasurer,,REP,Jeff Caton,283
+Lane,0052 7 EUGENE 237,State Treasurer,,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,State Treasurer,,REP,Under Votes,193
+Lane,0004 5 BLACHLY,State Treasurer,,REP,Jeff Caton,107
+Lane,0004 5 BLACHLY,State Treasurer,,REP,Over Votes,1
+Lane,0004 5 BLACHLY,State Treasurer,,REP,Under Votes,56
+Lane,0063 3 EUGENE 523,State Treasurer,,REP,Jeff Caton,594
+Lane,0063 3 EUGENE 523,State Treasurer,,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,State Treasurer,,REP,Under Votes,392
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,REP,Jeff Caton,548
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,State Treasurer,,REP,Under Votes,236
+Lane,0049 5 EUGENE 215,State Treasurer,,REP,Jeff Caton,317
+Lane,0049 5 EUGENE 215,State Treasurer,,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,State Treasurer,,REP,Under Votes,216
+Lane,0037 0 DUNES CITY,State Treasurer,,REP,Jeff Caton,159
+Lane,0037 0 DUNES CITY,State Treasurer,,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,State Treasurer,,REP,Under Votes,63
+Lane,0042 0 VENETA,State Treasurer,,REP,Jeff Caton,178
+Lane,0042 0 VENETA,State Treasurer,,REP,Over Votes,0
+Lane,0042 0 VENETA,State Treasurer,,REP,Under Votes,61
+Lane,0031 2 WALTERVILLE,State Treasurer,,REP,Jeff Caton,314
+Lane,0031 2 WALTERVILLE,State Treasurer,,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,State Treasurer,,REP,Under Votes,163
+Lane,0045 5 EUGENE 105,State Treasurer,,REP,Jeff Caton,34
+Lane,0045 5 EUGENE 105,State Treasurer,,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,State Treasurer,,REP,Under Votes,18
+Lane,0062 1 EUGENE 511,State Treasurer,,REP,Jeff Caton,614
+Lane,0062 1 EUGENE 511,State Treasurer,,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,State Treasurer,,REP,Under Votes,408
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,REP,Jeff Caton,49
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State Treasurer,,REP,Under Votes,43
+Lane,0055 7 EUGENE 317,State Treasurer,,REP,Jeff Caton,120
+Lane,0055 7 EUGENE 317,State Treasurer,,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,State Treasurer,,REP,Under Votes,104
+Lane,0039 2 FLORENCE 2,State Treasurer,,REP,Jeff Caton,465
+Lane,0039 2 FLORENCE 2,State Treasurer,,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,State Treasurer,,REP,Under Votes,181
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,REP,Jeff Caton,234
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,State Treasurer,,REP,Under Votes,87
+Lane,0060 5 EUGENE 505,State Treasurer,,REP,Jeff Caton,87
+Lane,0060 5 EUGENE 505,State Treasurer,,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,State Treasurer,,REP,Under Votes,34
+Lane,0046 7 EUGENE 107,State Treasurer,,REP,Jeff Caton,27
+Lane,0046 7 EUGENE 107,State Treasurer,,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,State Treasurer,,REP,Under Votes,13
+Lane,0008 2 CHESHIRE,State Treasurer,,REP,Jeff Caton,410
+Lane,0008 2 CHESHIRE,State Treasurer,,REP,Over Votes,0
+Lane,0008 2 CHESHIRE,State Treasurer,,REP,Under Votes,230
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,REP,Jeff Caton,124
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,State Treasurer,,REP,Under Votes,81
+Lane,0058 5 EUGENE 435,State Treasurer,,REP,Jeff Caton,426
+Lane,0058 5 EUGENE 435,State Treasurer,,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,State Treasurer,,REP,Under Votes,296
+Lane,0014 0 GOSHEN,State Treasurer,,REP,Jeff Caton,225
+Lane,0014 0 GOSHEN,State Treasurer,,REP,Over Votes,0
+Lane,0014 0 GOSHEN,State Treasurer,,REP,Under Votes,126
+Lane,0018 0 LORANE,State Treasurer,,REP,Jeff Caton,162
+Lane,0018 0 LORANE,State Treasurer,,REP,Over Votes,0
+Lane,0018 0 LORANE,State Treasurer,,REP,Under Votes,82
+Lane,0003 4 BAILEY,State Treasurer,,REP,Jeff Caton,192
+Lane,0003 4 BAILEY,State Treasurer,,REP,Over Votes,0
+Lane,0003 4 BAILEY,State Treasurer,,REP,Under Votes,122
+Lane,0011 4 FOX HOLLOW,State Treasurer,,REP,Jeff Caton,114
+Lane,0011 4 FOX HOLLOW,State Treasurer,,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State Treasurer,,REP,Under Votes,75
+Lane,0059 9 EUGENE 439,State Treasurer,,REP,Jeff Caton,524
+Lane,0059 9 EUGENE 439,State Treasurer,,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,State Treasurer,,REP,Under Votes,337
+Lane,0061 7 EUGENE 507,State Treasurer,,REP,Jeff Caton,261
+Lane,0061 7 EUGENE 507,State Treasurer,,REP,Over Votes,0
+Lane,0061 7 EUGENE 507,State Treasurer,,REP,Under Votes,147
+Lane,0034 0 COBURG,State Treasurer,,REP,Jeff Caton,63
+Lane,0034 0 COBURG,State Treasurer,,REP,Over Votes,0
+Lane,0034 0 COBURG,State Treasurer,,REP,Under Votes,49
+Lane,0038 1 FLORENCE 1,State Treasurer,,REP,Jeff Caton,358
+Lane,0038 1 FLORENCE 1,State Treasurer,,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,State Treasurer,,REP,Under Votes,137
+Lane,0051 5 EUGENE 235,State Treasurer,,REP,Jeff Caton,129
+Lane,0051 5 EUGENE 235,State Treasurer,,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,State Treasurer,,REP,Under Votes,101
+Lane,0016 5 GATEWAY,State Treasurer,,REP,Jeff Caton,100
+Lane,0016 5 GATEWAY,State Treasurer,,REP,Over Votes,0
+Lane,0016 5 GATEWAY,State Treasurer,,REP,Under Votes,38
+Lane,0021 5 MARCOLA,State Treasurer,,REP,Jeff Caton,115
+Lane,0021 5 MARCOLA,State Treasurer,,REP,Over Votes,0
+Lane,0021 5 MARCOLA,State Treasurer,,REP,Under Votes,65
+Lane,0019 2 LOWELL,State Treasurer,,REP,Jeff Caton,126
+Lane,0019 2 LOWELL,State Treasurer,,REP,Over Votes,0
+Lane,0019 2 LOWELL,State Treasurer,,REP,Under Votes,83
+Lane,0017 7 LATHAM,State Treasurer,,REP,Jeff Caton,265
+Lane,0017 7 LATHAM,State Treasurer,,REP,Over Votes,0
+Lane,0017 7 LATHAM,State Treasurer,,REP,Under Votes,156
+Lane,0048 7 EUGENE 117,State Treasurer,,REP,Jeff Caton,30
+Lane,0048 7 EUGENE 117,State Treasurer,,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,State Treasurer,,REP,Under Votes,12
+Lane,0006 8 COAST FORK,State Treasurer,,REP,Jeff Caton,255
+Lane,0006 8 COAST FORK,State Treasurer,,REP,Over Votes,0
+Lane,0006 8 COAST FORK,State Treasurer,,REP,Under Votes,126
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,REP,Jeff Caton,552
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,State Treasurer,,REP,Under Votes,401
+Lane,0050 3 EUGENE 223,State Treasurer,,REP,Jeff Caton,241
+Lane,0050 3 EUGENE 223,State Treasurer,,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,State Treasurer,,REP,Under Votes,179
+Lane,0009 0 ELMIRA,State Treasurer,,REP,Jeff Caton,242
+Lane,0009 0 ELMIRA,State Treasurer,,REP,Over Votes,0
+Lane,0009 0 ELMIRA,State Treasurer,,REP,Under Votes,107
+Lane,0025 6 RIVER ROAD,State Treasurer,,REP,Jeff Caton,348
+Lane,0025 6 RIVER ROAD,State Treasurer,,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,State Treasurer,,REP,Under Votes,189
+Lane,0022 7 MOSBY,State Treasurer,,REP,Jeff Caton,477
+Lane,0022 7 MOSBY,State Treasurer,,REP,Over Votes,0
+Lane,0022 7 MOSBY,State Treasurer,,REP,Under Votes,252
+Lane,0053 3 EUGENE 313,State Treasurer,,REP,Jeff Caton,54
+Lane,0053 3 EUGENE 313,State Treasurer,,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,State Treasurer,,REP,Under Votes,21
+Lane,0020 3 MAPLETON,State Treasurer,,REP,Jeff Caton,97
+Lane,0020 3 MAPLETON,State Treasurer,,REP,Over Votes,0
+Lane,0020 3 MAPLETON,State Treasurer,,REP,Under Votes,35
+Lane,0001 1 ALVADORE,State Treasurer,,REP,Jeff Caton,191
+Lane,0001 1 ALVADORE,State Treasurer,,REP,Over Votes,0
+Lane,0001 1 ALVADORE,State Treasurer,,REP,Under Votes,113
+Lane,0056 1 EUGENE 431,State Treasurer,,REP,Jeff Caton,99
+Lane,0056 1 EUGENE 431,State Treasurer,,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,State Treasurer,,REP,Under Votes,59
+Lane,0047 9 EUGENE 109,State Treasurer,,REP,Jeff Caton,6
+Lane,0047 9 EUGENE 109,State Treasurer,,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,State Treasurer,,REP,Under Votes,3
+Lane,0015 1 GROVEDALE,State Treasurer,,REP,Jeff Caton,108
+Lane,0015 1 GROVEDALE,State Treasurer,,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,State Treasurer,,REP,Under Votes,58
+Lane,0054 5 EUGENE 315,State Treasurer,,REP,Jeff Caton,96
+Lane,0054 5 EUGENE 315,State Treasurer,,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,State Treasurer,,REP,Under Votes,74
+Lane,0043 1 EUGENE 101,State Treasurer,,REP,Jeff Caton,330
+Lane,0043 1 EUGENE 101,State Treasurer,,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,State Treasurer,,REP,Under Votes,235
+Lane,0005 7 BLUE RIVER,State Treasurer,,REP,Jeff Caton,186
+Lane,0005 7 BLUE RIVER,State Treasurer,,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,State Treasurer,,REP,Under Votes,80
+Lane,0007 9 CAMAS,State Treasurer,,REP,Jeff Caton,41
+Lane,0007 9 CAMAS,State Treasurer,,REP,Over Votes,0
+Lane,0007 9 CAMAS,State Treasurer,,REP,Under Votes,37
+Lane,0036 0 CRESWELL,State Treasurer,,REP,Jeff Caton,193
+Lane,0036 0 CRESWELL,State Treasurer,,REP,Over Votes,0
+Lane,0036 0 CRESWELL,State Treasurer,,REP,Under Votes,111
+Lane,0012 6 GARDEN WAY,State Treasurer,,REP,Jeff Caton,22
+Lane,0012 6 GARDEN WAY,State Treasurer,,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,State Treasurer,,REP,Under Votes,11
+Lane,0032 3 WILKINS,State Treasurer,,REP,Jeff Caton,246
+Lane,0032 3 WILKINS,State Treasurer,,REP,Over Votes,0
+Lane,0032 3 WILKINS,State Treasurer,,REP,Under Votes,116
+Lane,0040 0 JUNCTION CITY,State Treasurer,,REP,Jeff Caton,270
+Lane,0040 0 JUNCTION CITY,State Treasurer,,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,State Treasurer,,REP,Under Votes,108
+Lane,0057 3 EUGENE 433,State Treasurer,,REP,Jeff Caton,241
+Lane,0057 3 EUGENE 433,State Treasurer,,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,State Treasurer,,REP,Under Votes,179
+Lane,0044 3 EUGENE 103,State Treasurer,,REP,Jeff Caton,132
+Lane,0044 3 EUGENE 103,State Treasurer,,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,State Treasurer,,REP,Under Votes,130
+Lane,0041 0 OAKRIDGE,State Treasurer,,REP,Jeff Caton,175
+Lane,0041 0 OAKRIDGE,State Treasurer,,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,State Treasurer,,REP,Under Votes,71
+Lane,0033 5 MCKENZIE,Attorney General,,REP,Paul Connolly,455
+Lane,0033 5 MCKENZIE,Attorney General,,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,Attorney General,,REP,Under Votes,222
+Lane,0026 9 SALMON CREEK,Attorney General,,REP,Paul Connolly,104
+Lane,0026 9 SALMON CREEK,Attorney General,,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,Attorney General,,REP,Under Votes,58
+Lane,0013 7 GLENADA,Attorney General,,REP,Paul Connolly,143
+Lane,0013 7 GLENADA,Attorney General,,REP,Over Votes,0
+Lane,0013 7 GLENADA,Attorney General,,REP,Under Votes,66
+Lane,0028 4 SANTA CLARA 4,Attorney General,,REP,Paul Connolly,455
+Lane,0028 4 SANTA CLARA 4,Attorney General,,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,Attorney General,,REP,Under Votes,164
+Lane,0010 2 FERNRIDGE,Attorney General,,REP,Paul Connolly,207
+Lane,0010 2 FERNRIDGE,Attorney General,,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,Attorney General,,REP,Under Votes,97
+Lane,0002 3 ARMITAGE,Attorney General,,REP,Paul Connolly,108
+Lane,0002 3 ARMITAGE,Attorney General,,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,Attorney General,,REP,Under Votes,67
+Lane,0030 0 SIUSLAW,Attorney General,,REP,Paul Connolly,297
+Lane,0030 0 SIUSLAW,Attorney General,,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,Attorney General,,REP,Under Votes,121
+Lane,0052 7 EUGENE 237,Attorney General,,REP,Paul Connolly,286
+Lane,0052 7 EUGENE 237,Attorney General,,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,Attorney General,,REP,Under Votes,191
+Lane,0004 5 BLACHLY,Attorney General,,REP,Paul Connolly,104
+Lane,0004 5 BLACHLY,Attorney General,,REP,Over Votes,0
+Lane,0004 5 BLACHLY,Attorney General,,REP,Under Votes,60
+Lane,0063 3 EUGENE 523,Attorney General,,REP,Paul Connolly,597
+Lane,0063 3 EUGENE 523,Attorney General,,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,Attorney General,,REP,Under Votes,388
+Lane,0035 0 COTTAGE GROVE,Attorney General,,REP,Paul Connolly,542
+Lane,0035 0 COTTAGE GROVE,Attorney General,,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,Attorney General,,REP,Under Votes,242
+Lane,0049 5 EUGENE 215,Attorney General,,REP,Paul Connolly,311
+Lane,0049 5 EUGENE 215,Attorney General,,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,Attorney General,,REP,Under Votes,222
+Lane,0037 0 DUNES CITY,Attorney General,,REP,Paul Connolly,160
+Lane,0037 0 DUNES CITY,Attorney General,,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,Attorney General,,REP,Under Votes,62
+Lane,0042 0 VENETA,Attorney General,,REP,Paul Connolly,172
+Lane,0042 0 VENETA,Attorney General,,REP,Over Votes,0
+Lane,0042 0 VENETA,Attorney General,,REP,Under Votes,67
+Lane,0031 2 WALTERVILLE,Attorney General,,REP,Paul Connolly,307
+Lane,0031 2 WALTERVILLE,Attorney General,,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,Attorney General,,REP,Under Votes,166
+Lane,0045 5 EUGENE 105,Attorney General,,REP,Paul Connolly,34
+Lane,0045 5 EUGENE 105,Attorney General,,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,Attorney General,,REP,Under Votes,18
+Lane,0062 1 EUGENE 511,Attorney General,,REP,Paul Connolly,614
+Lane,0062 1 EUGENE 511,Attorney General,,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,Attorney General,,REP,Under Votes,405
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,REP,Paul Connolly,47
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,Attorney General,,REP,Under Votes,45
+Lane,0055 7 EUGENE 317,Attorney General,,REP,Paul Connolly,117
+Lane,0055 7 EUGENE 317,Attorney General,,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,Attorney General,,REP,Under Votes,107
+Lane,0039 2 FLORENCE 2,Attorney General,,REP,Paul Connolly,470
+Lane,0039 2 FLORENCE 2,Attorney General,,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,Attorney General,,REP,Under Votes,179
+Lane,0029 8 SANTA CLARA 8,Attorney General,,REP,Paul Connolly,233
+Lane,0029 8 SANTA CLARA 8,Attorney General,,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,Attorney General,,REP,Under Votes,86
+Lane,0060 5 EUGENE 505,Attorney General,,REP,Paul Connolly,89
+Lane,0060 5 EUGENE 505,Attorney General,,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,Attorney General,,REP,Under Votes,33
+Lane,0046 7 EUGENE 107,Attorney General,,REP,Paul Connolly,27
+Lane,0046 7 EUGENE 107,Attorney General,,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,Attorney General,,REP,Under Votes,13
+Lane,0008 2 CHESHIRE,Attorney General,,REP,Paul Connolly,416
+Lane,0008 2 CHESHIRE,Attorney General,,REP,Over Votes,0
+Lane,0008 2 CHESHIRE,Attorney General,,REP,Under Votes,225
+Lane,0027 1 SANTA CLARA 1,Attorney General,,REP,Paul Connolly,123
+Lane,0027 1 SANTA CLARA 1,Attorney General,,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,Attorney General,,REP,Under Votes,82
+Lane,0058 5 EUGENE 435,Attorney General,,REP,Paul Connolly,429
+Lane,0058 5 EUGENE 435,Attorney General,,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,Attorney General,,REP,Under Votes,293
+Lane,0014 0 GOSHEN,Attorney General,,REP,Paul Connolly,226
+Lane,0014 0 GOSHEN,Attorney General,,REP,Over Votes,0
+Lane,0014 0 GOSHEN,Attorney General,,REP,Under Votes,125
+Lane,0018 0 LORANE,Attorney General,,REP,Paul Connolly,163
+Lane,0018 0 LORANE,Attorney General,,REP,Over Votes,0
+Lane,0018 0 LORANE,Attorney General,,REP,Under Votes,81
+Lane,0003 4 BAILEY,Attorney General,,REP,Paul Connolly,193
+Lane,0003 4 BAILEY,Attorney General,,REP,Over Votes,0
+Lane,0003 4 BAILEY,Attorney General,,REP,Under Votes,121
+Lane,0011 4 FOX HOLLOW,Attorney General,,REP,Paul Connolly,118
+Lane,0011 4 FOX HOLLOW,Attorney General,,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,Attorney General,,REP,Under Votes,73
+Lane,0059 9 EUGENE 439,Attorney General,,REP,Paul Connolly,526
+Lane,0059 9 EUGENE 439,Attorney General,,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,Attorney General,,REP,Under Votes,337
+Lane,0061 7 EUGENE 507,Attorney General,,REP,Paul Connolly,263
+Lane,0061 7 EUGENE 507,Attorney General,,REP,Over Votes,0
+Lane,0061 7 EUGENE 507,Attorney General,,REP,Under Votes,145
+Lane,0034 0 COBURG,Attorney General,,REP,Paul Connolly,63
+Lane,0034 0 COBURG,Attorney General,,REP,Over Votes,0
+Lane,0034 0 COBURG,Attorney General,,REP,Under Votes,49
+Lane,0038 1 FLORENCE 1,Attorney General,,REP,Paul Connolly,356
+Lane,0038 1 FLORENCE 1,Attorney General,,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,Attorney General,,REP,Under Votes,139
+Lane,0051 5 EUGENE 235,Attorney General,,REP,Paul Connolly,133
+Lane,0051 5 EUGENE 235,Attorney General,,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,Attorney General,,REP,Under Votes,96
+Lane,0016 5 GATEWAY,Attorney General,,REP,Paul Connolly,101
+Lane,0016 5 GATEWAY,Attorney General,,REP,Over Votes,0
+Lane,0016 5 GATEWAY,Attorney General,,REP,Under Votes,37
+Lane,0021 5 MARCOLA,Attorney General,,REP,Paul Connolly,121
+Lane,0021 5 MARCOLA,Attorney General,,REP,Over Votes,0
+Lane,0021 5 MARCOLA,Attorney General,,REP,Under Votes,60
+Lane,0019 2 LOWELL,Attorney General,,REP,Paul Connolly,124
+Lane,0019 2 LOWELL,Attorney General,,REP,Over Votes,0
+Lane,0019 2 LOWELL,Attorney General,,REP,Under Votes,86
+Lane,0017 7 LATHAM,Attorney General,,REP,Paul Connolly,256
+Lane,0017 7 LATHAM,Attorney General,,REP,Over Votes,0
+Lane,0017 7 LATHAM,Attorney General,,REP,Under Votes,163
+Lane,0048 7 EUGENE 117,Attorney General,,REP,Paul Connolly,27
+Lane,0048 7 EUGENE 117,Attorney General,,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,Attorney General,,REP,Under Votes,14
+Lane,0006 8 COAST FORK,Attorney General,,REP,Paul Connolly,255
+Lane,0006 8 COAST FORK,Attorney General,,REP,Over Votes,0
+Lane,0006 8 COAST FORK,Attorney General,,REP,Under Votes,127
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,REP,Paul Connolly,552
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,Attorney General,,REP,Under Votes,403
+Lane,0050 3 EUGENE 223,Attorney General,,REP,Paul Connolly,252
+Lane,0050 3 EUGENE 223,Attorney General,,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,Attorney General,,REP,Under Votes,170
+Lane,0009 0 ELMIRA,Attorney General,,REP,Paul Connolly,236
+Lane,0009 0 ELMIRA,Attorney General,,REP,Over Votes,0
+Lane,0009 0 ELMIRA,Attorney General,,REP,Under Votes,113
+Lane,0025 6 RIVER ROAD,Attorney General,,REP,Paul Connolly,334
+Lane,0025 6 RIVER ROAD,Attorney General,,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,Attorney General,,REP,Under Votes,206
+Lane,0022 7 MOSBY,Attorney General,,REP,Paul Connolly,476
+Lane,0022 7 MOSBY,Attorney General,,REP,Over Votes,0
+Lane,0022 7 MOSBY,Attorney General,,REP,Under Votes,253
+Lane,0053 3 EUGENE 313,Attorney General,,REP,Paul Connolly,53
+Lane,0053 3 EUGENE 313,Attorney General,,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,Attorney General,,REP,Under Votes,22
+Lane,0020 3 MAPLETON,Attorney General,,REP,Paul Connolly,101
+Lane,0020 3 MAPLETON,Attorney General,,REP,Over Votes,0
+Lane,0020 3 MAPLETON,Attorney General,,REP,Under Votes,31
+Lane,0001 1 ALVADORE,Attorney General,,REP,Paul Connolly,198
+Lane,0001 1 ALVADORE,Attorney General,,REP,Over Votes,0
+Lane,0001 1 ALVADORE,Attorney General,,REP,Under Votes,108
+Lane,0056 1 EUGENE 431,Attorney General,,REP,Paul Connolly,99
+Lane,0056 1 EUGENE 431,Attorney General,,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,Attorney General,,REP,Under Votes,60
+Lane,0047 9 EUGENE 109,Attorney General,,REP,Paul Connolly,6
+Lane,0047 9 EUGENE 109,Attorney General,,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,Attorney General,,REP,Under Votes,3
+Lane,0015 1 GROVEDALE,Attorney General,,REP,Paul Connolly,109
+Lane,0015 1 GROVEDALE,Attorney General,,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,Attorney General,,REP,Under Votes,55
+Lane,0054 5 EUGENE 315,Attorney General,,REP,Paul Connolly,95
+Lane,0054 5 EUGENE 315,Attorney General,,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,Attorney General,,REP,Under Votes,75
+Lane,0043 1 EUGENE 101,Attorney General,,REP,Paul Connolly,329
+Lane,0043 1 EUGENE 101,Attorney General,,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,Attorney General,,REP,Under Votes,233
+Lane,0005 7 BLUE RIVER,Attorney General,,REP,Paul Connolly,187
+Lane,0005 7 BLUE RIVER,Attorney General,,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,Attorney General,,REP,Under Votes,79
+Lane,0007 9 CAMAS,Attorney General,,REP,Paul Connolly,42
+Lane,0007 9 CAMAS,Attorney General,,REP,Over Votes,0
+Lane,0007 9 CAMAS,Attorney General,,REP,Under Votes,36
+Lane,0036 0 CRESWELL,Attorney General,,REP,Paul Connolly,197
+Lane,0036 0 CRESWELL,Attorney General,,REP,Over Votes,0
+Lane,0036 0 CRESWELL,Attorney General,,REP,Under Votes,108
+Lane,0012 6 GARDEN WAY,Attorney General,,REP,Paul Connolly,19
+Lane,0012 6 GARDEN WAY,Attorney General,,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,Attorney General,,REP,Under Votes,13
+Lane,0032 3 WILKINS,Attorney General,,REP,Paul Connolly,249
+Lane,0032 3 WILKINS,Attorney General,,REP,Over Votes,0
+Lane,0032 3 WILKINS,Attorney General,,REP,Under Votes,113
+Lane,0040 0 JUNCTION CITY,Attorney General,,REP,Paul Connolly,275
+Lane,0040 0 JUNCTION CITY,Attorney General,,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,Attorney General,,REP,Under Votes,102
+Lane,0057 3 EUGENE 433,Attorney General,,REP,Paul Connolly,243
+Lane,0057 3 EUGENE 433,Attorney General,,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,Attorney General,,REP,Under Votes,179
+Lane,0044 3 EUGENE 103,Attorney General,,REP,Paul Connolly,133
+Lane,0044 3 EUGENE 103,Attorney General,,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,Attorney General,,REP,Under Votes,130
+Lane,0041 0 OAKRIDGE,Attorney General,,REP,Paul Connolly,178
+Lane,0041 0 OAKRIDGE,Attorney General,,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,Attorney General,,REP,Under Votes,72
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,REP,Jeff Caton,318
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,State Treasurer,,REP,Under Votes,143
+Lane,0064 3 EUGENE 613,State Treasurer,,REP,Jeff Caton,378
+Lane,0064 3 EUGENE 613,State Treasurer,,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,State Treasurer,,REP,Under Votes,216
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,REP,Jeff Caton,147
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,State Treasurer,,REP,Under Votes,90
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,REP,Jeff Caton,339
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State Treasurer,,REP,Under Votes,121
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,REP,Jeff Caton,344
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State Treasurer,,REP,Under Votes,161
+Lane,0072 3 EUGENE 723,State Treasurer,,REP,Jeff Caton,213
+Lane,0072 3 EUGENE 723,State Treasurer,,REP,Over Votes,0
+Lane,0072 3 EUGENE 723,State Treasurer,,REP,Under Votes,113
+Lane,0070 7 EUGENE 717,State Treasurer,,REP,Jeff Caton,17
+Lane,0070 7 EUGENE 717,State Treasurer,,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,State Treasurer,,REP,Under Votes,9
+Lane,0074 5 EUGENE 805,State Treasurer,,REP,Jeff Caton,159
+Lane,0074 5 EUGENE 805,State Treasurer,,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,State Treasurer,,REP,Under Votes,86
+Lane,0065 7 EUGENE 617,State Treasurer,,REP,Jeff Caton,499
+Lane,0065 7 EUGENE 617,State Treasurer,,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,State Treasurer,,REP,Under Votes,242
+Lane,0069 5 EUGENE 715,State Treasurer,,REP,Jeff Caton,17
+Lane,0069 5 EUGENE 715,State Treasurer,,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,State Treasurer,,REP,Under Votes,5
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,REP,Jeff Caton,298
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State Treasurer,,REP,Under Votes,151
+Lane,0067 1 EUGENE 711,State Treasurer,,REP,Jeff Caton,55
+Lane,0067 1 EUGENE 711,State Treasurer,,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,State Treasurer,,REP,Under Votes,21
+Lane,0071 9 EUGENE 719,State Treasurer,,REP,Jeff Caton,23
+Lane,0071 9 EUGENE 719,State Treasurer,,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,State Treasurer,,REP,Under Votes,28
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,REP,Jeff Caton,355
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,State Treasurer,,REP,Under Votes,176
+Lane,0068 3 EUGENE 713,State Treasurer,,REP,Jeff Caton,343
+Lane,0068 3 EUGENE 713,State Treasurer,,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,State Treasurer,,REP,Under Votes,214
+Lane,0075 7 EUGENE 807,State Treasurer,,REP,Jeff Caton,553
+Lane,0075 7 EUGENE 807,State Treasurer,,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,State Treasurer,,REP,Under Votes,362
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,REP,Jeff Caton,384
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,State Treasurer,,REP,Under Votes,143
+Lane,0073 3 EUGENE 803,State Treasurer,,REP,Jeff Caton,98
+Lane,0073 3 EUGENE 803,State Treasurer,,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,State Treasurer,,REP,Under Votes,54
+Lane,0066 3 EUGENE 623,State Treasurer,,REP,Jeff Caton,345
+Lane,0066 3 EUGENE 623,State Treasurer,,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,State Treasurer,,REP,Under Votes,186
+Lane,0076 9 EUGENE 809,State Treasurer,,REP,Jeff Caton,110
+Lane,0076 9 EUGENE 809,State Treasurer,,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,State Treasurer,,REP,Under Votes,60
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,REP,Paul Connolly,308
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,Attorney General,,REP,Under Votes,148
+Lane,0064 3 EUGENE 613,Attorney General,,REP,Paul Connolly,384
+Lane,0064 3 EUGENE 613,Attorney General,,REP,Over Votes,0
+Lane,0064 3 EUGENE 613,Attorney General,,REP,Under Votes,216
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,REP,Paul Connolly,149
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,Attorney General,,REP,Under Votes,88
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,REP,Paul Connolly,336
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,Attorney General,,REP,Under Votes,124
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,REP,Paul Connolly,337
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,Attorney General,,REP,Under Votes,168
+Lane,0072 3 EUGENE 723,Attorney General,,REP,Paul Connolly,215
+Lane,0072 3 EUGENE 723,Attorney General,,REP,Over Votes,0
+Lane,0072 3 EUGENE 723,Attorney General,,REP,Under Votes,109
+Lane,0070 7 EUGENE 717,Attorney General,,REP,Paul Connolly,15
+Lane,0070 7 EUGENE 717,Attorney General,,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,Attorney General,,REP,Under Votes,11
+Lane,0074 5 EUGENE 805,Attorney General,,REP,Paul Connolly,155
+Lane,0074 5 EUGENE 805,Attorney General,,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,Attorney General,,REP,Under Votes,91
+Lane,0065 7 EUGENE 617,Attorney General,,REP,Paul Connolly,497
+Lane,0065 7 EUGENE 617,Attorney General,,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,Attorney General,,REP,Under Votes,242
+Lane,0069 5 EUGENE 715,Attorney General,,REP,Paul Connolly,17
+Lane,0069 5 EUGENE 715,Attorney General,,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,Attorney General,,REP,Under Votes,5
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,REP,Paul Connolly,293
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,Attorney General,,REP,Under Votes,154
+Lane,0067 1 EUGENE 711,Attorney General,,REP,Paul Connolly,51
+Lane,0067 1 EUGENE 711,Attorney General,,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,Attorney General,,REP,Under Votes,23
+Lane,0071 9 EUGENE 719,Attorney General,,REP,Paul Connolly,22
+Lane,0071 9 EUGENE 719,Attorney General,,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,Attorney General,,REP,Under Votes,29
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,REP,Paul Connolly,347
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,Attorney General,,REP,Under Votes,182
+Lane,0068 3 EUGENE 713,Attorney General,,REP,Paul Connolly,342
+Lane,0068 3 EUGENE 713,Attorney General,,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,Attorney General,,REP,Under Votes,217
+Lane,0075 7 EUGENE 807,Attorney General,,REP,Paul Connolly,543
+Lane,0075 7 EUGENE 807,Attorney General,,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,Attorney General,,REP,Under Votes,373
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,REP,Paul Connolly,383
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,Attorney General,,REP,Under Votes,147
+Lane,0073 3 EUGENE 803,Attorney General,,REP,Paul Connolly,95
+Lane,0073 3 EUGENE 803,Attorney General,,REP,Over Votes,1
+Lane,0073 3 EUGENE 803,Attorney General,,REP,Under Votes,57
+Lane,0066 3 EUGENE 623,Attorney General,,REP,Paul Connolly,347
+Lane,0066 3 EUGENE 623,Attorney General,,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,Attorney General,,REP,Under Votes,185
+Lane,0076 9 EUGENE 809,Attorney General,,REP,Paul Connolly,111
+Lane,0076 9 EUGENE 809,Attorney General,,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,Attorney General,,REP,Under Votes,59
+Lane,0026 9 SALMON CREEK,State Senate,4,REP,Norm Thomas,98
+Lane,0026 9 SALMON CREEK,State Senate,4,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,State Senate,4,REP,Under Votes,64
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,REP,Norm Thomas,44
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State Senate,4,REP,Under Votes,48
+Lane,0010 2 FERNRIDGE,State Senate,4,REP,Norm Thomas,206
+Lane,0010 2 FERNRIDGE,State Senate,4,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,State Senate,4,REP,Under Votes,97
+Lane,0003 4 BAILEY,State Senate,4,REP,Norm Thomas,193
+Lane,0003 4 BAILEY,State Senate,4,REP,Over Votes,0
+Lane,0003 4 BAILEY,State Senate,4,REP,Under Votes,120
+Lane,0052 7 EUGENE 237,State Senate,4,REP,Norm Thomas,282
+Lane,0052 7 EUGENE 237,State Senate,4,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,State Senate,4,REP,Under Votes,194
+Lane,0035 0 COTTAGE GROVE,State Senate,4,REP,Norm Thomas,549
+Lane,0035 0 COTTAGE GROVE,State Senate,4,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,State Senate,4,REP,Under Votes,235
+Lane,0069 5 EUGENE 715,State Senate,4,REP,Norm Thomas,15
+Lane,0069 5 EUGENE 715,State Senate,4,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,State Senate,4,REP,Under Votes,6
+Lane,0042 0 VENETA,State Senate,4,REP,Norm Thomas,159
+Lane,0042 0 VENETA,State Senate,4,REP,Over Votes,0
+Lane,0042 0 VENETA,State Senate,4,REP,Under Votes,78
+Lane,0075 7 EUGENE 807,State Senate,4,REP,Norm Thomas,557
+Lane,0075 7 EUGENE 807,State Senate,4,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,State Senate,4,REP,Under Votes,359
+Lane,0018 0 LORANE,State Senate,4,REP,Norm Thomas,160
+Lane,0018 0 LORANE,State Senate,4,REP,Over Votes,0
+Lane,0018 0 LORANE,State Senate,4,REP,Under Votes,85
+Lane,0011 4 FOX HOLLOW,State Senate,4,REP,Norm Thomas,116
+Lane,0011 4 FOX HOLLOW,State Senate,4,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State Senate,4,REP,Under Votes,74
+Lane,0051 5 EUGENE 235,State Senate,4,REP,Norm Thomas,132
+Lane,0051 5 EUGENE 235,State Senate,4,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,State Senate,4,REP,Under Votes,98
+Lane,0041 0 OAKRIDGE,State Senate,4,REP,Norm Thomas,174
+Lane,0041 0 OAKRIDGE,State Senate,4,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,State Senate,4,REP,Under Votes,70
+Lane,0019 2 LOWELL,State Senate,4,REP,Norm Thomas,120
+Lane,0019 2 LOWELL,State Senate,4,REP,Over Votes,0
+Lane,0019 2 LOWELL,State Senate,4,REP,Under Votes,89
+Lane,0017 7 LATHAM,State Senate,4,REP,Norm Thomas,255
+Lane,0017 7 LATHAM,State Senate,4,REP,Over Votes,0
+Lane,0017 7 LATHAM,State Senate,4,REP,Under Votes,165
+Lane,0022 7 MOSBY,State Senate,4,REP,Norm Thomas,473
+Lane,0022 7 MOSBY,State Senate,4,REP,Over Votes,0
+Lane,0022 7 MOSBY,State Senate,4,REP,Under Votes,257
+Lane,0053 3 EUGENE 313,State Senate,4,REP,Norm Thomas,53
+Lane,0053 3 EUGENE 313,State Senate,4,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,State Senate,4,REP,Under Votes,21
+Lane,0054 5 EUGENE 315,State Senate,4,REP,Norm Thomas,101
+Lane,0054 5 EUGENE 315,State Senate,4,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,State Senate,4,REP,Under Votes,69
+Lane,0070 7 EUGENE 717,State Senate,4,REP,Norm Thomas,15
+Lane,0070 7 EUGENE 717,State Senate,4,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,State Senate,4,REP,Under Votes,11
+Lane,0005 7 BLUE RIVER,State Senate,4,REP,Norm Thomas,175
+Lane,0005 7 BLUE RIVER,State Senate,4,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,State Senate,4,REP,Under Votes,90
+Lane,0007 9 CAMAS,State Senate,4,REP,Norm Thomas,41
+Lane,0007 9 CAMAS,State Senate,4,REP,Over Votes,0
+Lane,0007 9 CAMAS,State Senate,4,REP,Under Votes,36
+Lane,0043 1 EUGENE 101,State Senate,4,REP,Norm Thomas,319
+Lane,0043 1 EUGENE 101,State Senate,4,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,State Senate,4,REP,Under Votes,244
+Lane,0076 9 EUGENE 809,State Senate,4,REP,Norm Thomas,105
+Lane,0076 9 EUGENE 809,State Senate,4,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,State Senate,4,REP,Under Votes,64
+Lane,0044 3 EUGENE 103,State Senate,4,REP,Norm Thomas,138
+Lane,0044 3 EUGENE 103,State Senate,4,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,State Senate,4,REP,Under Votes,125
+Lane,0020 3 MAPLETON,State Senate,5,REP,Al Pearn,105
+Lane,0020 3 MAPLETON,State Senate,5,REP,Over Votes,0
+Lane,0020 3 MAPLETON,State Senate,5,REP,Under Votes,28
+Lane,0030 0 SIUSLAW,State Senate,5,REP,Al Pearn,322
+Lane,0030 0 SIUSLAW,State Senate,5,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,State Senate,5,REP,Under Votes,95
+Lane,0013 7 GLENADA,State Senate,5,REP,Al Pearn,164
+Lane,0013 7 GLENADA,State Senate,5,REP,Over Votes,0
+Lane,0013 7 GLENADA,State Senate,5,REP,Under Votes,45
+Lane,0038 1 FLORENCE 1,State Senate,5,REP,Al Pearn,379
+Lane,0038 1 FLORENCE 1,State Senate,5,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,State Senate,5,REP,Under Votes,115
+Lane,0004 5 BLACHLY,State Senate,5,REP,Al Pearn,103
+Lane,0004 5 BLACHLY,State Senate,5,REP,Over Votes,0
+Lane,0004 5 BLACHLY,State Senate,5,REP,Under Votes,59
+Lane,0037 0 DUNES CITY,State Senate,5,REP,Al Pearn,177
+Lane,0037 0 DUNES CITY,State Senate,5,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,State Senate,5,REP,Under Votes,43
+Lane,0009 0 ELMIRA,State Senate,5,REP,Al Pearn,236
+Lane,0009 0 ELMIRA,State Senate,5,REP,Over Votes,0
+Lane,0009 0 ELMIRA,State Senate,5,REP,Under Votes,116
+Lane,0039 2 FLORENCE 2,State Senate,5,REP,Al Pearn,492
+Lane,0039 2 FLORENCE 2,State Senate,5,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,State Senate,5,REP,Under Votes,156
+Lane,0026 9 SALMON CREEK,State House,7,REP,Bruce L. Hanna,107
+Lane,0026 9 SALMON CREEK,State House,7,REP,Over Votes,0
+Lane,0026 9 SALMON CREEK,State House,7,REP,Under Votes,57
+Lane,0024 2 PLEASANT HILL 2,State House,7,REP,Bruce L. Hanna,48
+Lane,0024 2 PLEASANT HILL 2,State House,7,REP,Over Votes,0
+Lane,0024 2 PLEASANT HILL 2,State House,7,REP,Under Votes,44
+Lane,0017 7 LATHAM,State House,7,REP,Bruce L. Hanna,257
+Lane,0017 7 LATHAM,State House,7,REP,Over Votes,0
+Lane,0017 7 LATHAM,State House,7,REP,Under Votes,162
+Lane,0041 0 OAKRIDGE,State House,7,REP,Bruce L. Hanna,178
+Lane,0041 0 OAKRIDGE,State House,7,REP,Over Votes,0
+Lane,0041 0 OAKRIDGE,State House,7,REP,Under Votes,68
+Lane,0035 0 COTTAGE GROVE,State House,7,REP,Bruce L. Hanna,566
+Lane,0035 0 COTTAGE GROVE,State House,7,REP,Over Votes,0
+Lane,0035 0 COTTAGE GROVE,State House,7,REP,Under Votes,221
+Lane,0005 7 BLUE RIVER,State House,7,REP,Bruce L. Hanna,184
+Lane,0005 7 BLUE RIVER,State House,7,REP,Over Votes,0
+Lane,0005 7 BLUE RIVER,State House,7,REP,Under Votes,82
+Lane,0019 2 LOWELL,State House,7,REP,Bruce L. Hanna,136
+Lane,0019 2 LOWELL,State House,7,REP,Over Votes,0
+Lane,0019 2 LOWELL,State House,7,REP,Under Votes,74
+Lane,0007 9 CAMAS,State House,7,REP,Bruce L. Hanna,39
+Lane,0007 9 CAMAS,State House,7,REP,Over Votes,0
+Lane,0007 9 CAMAS,State House,7,REP,Under Votes,39
+Lane,0022 7 MOSBY,State House,7,REP,Bruce L. Hanna,488
+Lane,0022 7 MOSBY,State House,7,REP,Over Votes,0
+Lane,0022 7 MOSBY,State House,7,REP,Under Votes,242
+Lane,0051 5 EUGENE 235,State House,8,REP,Bill Young,135
+Lane,0051 5 EUGENE 235,State House,8,REP,Over Votes,0
+Lane,0051 5 EUGENE 235,State House,8,REP,Under Votes,96
+Lane,0011 4 FOX HOLLOW,State House,8,REP,Bill Young,114
+Lane,0011 4 FOX HOLLOW,State House,8,REP,Over Votes,0
+Lane,0011 4 FOX HOLLOW,State House,8,REP,Under Votes,75
+Lane,0053 3 EUGENE 313,State House,8,REP,Bill Young,53
+Lane,0053 3 EUGENE 313,State House,8,REP,Over Votes,0
+Lane,0053 3 EUGENE 313,State House,8,REP,Under Votes,22
+Lane,0054 5 EUGENE 315,State House,8,REP,Bill Young,99
+Lane,0054 5 EUGENE 315,State House,8,REP,Over Votes,0
+Lane,0054 5 EUGENE 315,State House,8,REP,Under Votes,70
+Lane,0010 2 FERNRIDGE,State House,8,REP,Bill Young,202
+Lane,0010 2 FERNRIDGE,State House,8,REP,Over Votes,0
+Lane,0010 2 FERNRIDGE,State House,8,REP,Under Votes,103
+Lane,0003 4 BAILEY,State House,8,REP,Bill Young,195
+Lane,0003 4 BAILEY,State House,8,REP,Over Votes,0
+Lane,0003 4 BAILEY,State House,8,REP,Under Votes,120
+Lane,0044 3 EUGENE 103,State House,8,REP,Bill Young,132
+Lane,0044 3 EUGENE 103,State House,8,REP,Over Votes,0
+Lane,0044 3 EUGENE 103,State House,8,REP,Under Votes,131
+Lane,0052 7 EUGENE 237,State House,8,REP,Bill Young,286
+Lane,0052 7 EUGENE 237,State House,8,REP,Over Votes,0
+Lane,0052 7 EUGENE 237,State House,8,REP,Under Votes,192
+Lane,0070 7 EUGENE 717,State House,8,REP,Bill Young,14
+Lane,0070 7 EUGENE 717,State House,8,REP,Over Votes,0
+Lane,0070 7 EUGENE 717,State House,8,REP,Under Votes,12
+Lane,0043 1 EUGENE 101,State House,8,REP,Bill Young,322
+Lane,0043 1 EUGENE 101,State House,8,REP,Over Votes,0
+Lane,0043 1 EUGENE 101,State House,8,REP,Under Votes,243
+Lane,0069 5 EUGENE 715,State House,8,REP,Bill Young,16
+Lane,0069 5 EUGENE 715,State House,8,REP,Over Votes,0
+Lane,0069 5 EUGENE 715,State House,8,REP,Under Votes,5
+Lane,0042 0 VENETA,State House,8,REP,Bill Young,163
+Lane,0042 0 VENETA,State House,8,REP,Over Votes,0
+Lane,0042 0 VENETA,State House,8,REP,Under Votes,75
+Lane,0075 7 EUGENE 807,State House,8,REP,Bill Young,559
+Lane,0075 7 EUGENE 807,State House,8,REP,Over Votes,0
+Lane,0075 7 EUGENE 807,State House,8,REP,Under Votes,356
+Lane,0018 0 LORANE,State House,8,REP,Bill Young,155
+Lane,0018 0 LORANE,State House,8,REP,Over Votes,0
+Lane,0018 0 LORANE,State House,8,REP,Under Votes,90
+Lane,0076 9 EUGENE 809,State House,8,REP,Bill Young,108
+Lane,0076 9 EUGENE 809,State House,8,REP,Over Votes,0
+Lane,0076 9 EUGENE 809,State House,8,REP,Under Votes,63
+Lane,0039 2 FLORENCE 2,State House,9,REP,Susan Massey,444
+Lane,0039 2 FLORENCE 2,State House,9,REP,Over Votes,0
+Lane,0039 2 FLORENCE 2,State House,9,REP,Under Votes,202
+Lane,0038 1 FLORENCE 1,State House,9,REP,Susan Massey,350
+Lane,0038 1 FLORENCE 1,State House,9,REP,Over Votes,0
+Lane,0038 1 FLORENCE 1,State House,9,REP,Under Votes,146
+Lane,0013 7 GLENADA,State House,9,REP,Susan Massey,129
+Lane,0013 7 GLENADA,State House,9,REP,Over Votes,0
+Lane,0013 7 GLENADA,State House,9,REP,Under Votes,77
+Lane,0037 0 DUNES CITY,State House,9,REP,Susan Massey,157
+Lane,0037 0 DUNES CITY,State House,9,REP,Over Votes,0
+Lane,0037 0 DUNES CITY,State House,9,REP,Under Votes,65
+Lane,0004 5 BLACHLY,State House,10,REP,Alan Brown,116
+Lane,0004 5 BLACHLY,State House,10,REP,Over Votes,0
+Lane,0004 5 BLACHLY,State House,10,REP,Under Votes,48
+Lane,0020 3 MAPLETON,State House,10,REP,Alan Brown,102
+Lane,0020 3 MAPLETON,State House,10,REP,Over Votes,0
+Lane,0020 3 MAPLETON,State House,10,REP,Under Votes,29
+Lane,0030 0 SIUSLAW,State House,10,REP,Alan Brown,301
+Lane,0030 0 SIUSLAW,State House,10,REP,Over Votes,0
+Lane,0030 0 SIUSLAW,State House,10,REP,Under Votes,116
+Lane,0009 0 ELMIRA,State House,10,REP,Alan Brown,243
+Lane,0009 0 ELMIRA,State House,10,REP,Over Votes,0
+Lane,0009 0 ELMIRA,State House,10,REP,Under Votes,109
+Lane,0033 5 MCKENZIE,State House,11,REP,Michael P. Spasaro,444
+Lane,0033 5 MCKENZIE,State House,11,REP,Over Votes,0
+Lane,0033 5 MCKENZIE,State House,11,REP,Under Votes,235
+Lane,0055 7 EUGENE 317,State House,11,REP,Michael P. Spasaro,116
+Lane,0055 7 EUGENE 317,State House,11,REP,Over Votes,0
+Lane,0055 7 EUGENE 317,State House,11,REP,Under Votes,105
+Lane,0034 0 COBURG,State House,11,REP,Michael P. Spasaro,60
+Lane,0034 0 COBURG,State House,11,REP,Over Votes,0
+Lane,0034 0 COBURG,State House,11,REP,Under Votes,51
+Lane,0015 1 GROVEDALE,State House,11,REP,Michael P. Spasaro,103
+Lane,0015 1 GROVEDALE,State House,11,REP,Over Votes,0
+Lane,0015 1 GROVEDALE,State House,11,REP,Under Votes,63
+Lane,0081 4 SPRINGFIELD 504,State House,11,REP,Michael P. Spasaro,9
+Lane,0081 4 SPRINGFIELD 504,State House,11,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State House,11,REP,Under Votes,2
+Lane,0077 2 SPRINGFIELD 102,State House,11,REP,Michael P. Spasaro,0
+Lane,0077 2 SPRINGFIELD 102,State House,11,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State House,11,REP,Under Votes,1
+Lane,0059 9 EUGENE 439,State House,11,REP,Michael P. Spasaro,0
+Lane,0059 9 EUGENE 439,State House,11,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,State House,11,REP,Under Votes,0
+Lane,0032 3 WILKINS,State House,11,REP,Michael P. Spasaro,245
+Lane,0032 3 WILKINS,State House,11,REP,Over Votes,0
+Lane,0032 3 WILKINS,State House,11,REP,Under Votes,117
+Lane,0021 5 MARCOLA,State House,11,REP,Michael P. Spasaro,114
+Lane,0021 5 MARCOLA,State House,11,REP,Over Votes,0
+Lane,0021 5 MARCOLA,State House,11,REP,Under Votes,65
+Lane,0049 5 EUGENE 215,State House,11,REP,Michael P. Spasaro,299
+Lane,0049 5 EUGENE 215,State House,11,REP,Over Votes,0
+Lane,0049 5 EUGENE 215,State House,11,REP,Under Votes,234
+Lane,0036 0 CRESWELL,State House,11,REP,Michael P. Spasaro,196
+Lane,0036 0 CRESWELL,State House,11,REP,Over Votes,0
+Lane,0036 0 CRESWELL,State House,11,REP,Under Votes,108
+Lane,0063 3 EUGENE 523,State House,11,REP,Michael P. Spasaro,2
+Lane,0063 3 EUGENE 523,State House,11,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,State House,11,REP,Under Votes,8
+Lane,0031 2 WALTERVILLE,State House,11,REP,Michael P. Spasaro,302
+Lane,0031 2 WALTERVILLE,State House,11,REP,Over Votes,0
+Lane,0031 2 WALTERVILLE,State House,11,REP,Under Votes,174
+Lane,0006 8 COAST FORK,State House,11,REP,Michael P. Spasaro,244
+Lane,0006 8 COAST FORK,State House,11,REP,Over Votes,0
+Lane,0006 8 COAST FORK,State House,11,REP,Under Votes,138
+Lane,0014 0 GOSHEN,State House,11,REP,Michael P. Spasaro,218
+Lane,0014 0 GOSHEN,State House,11,REP,Over Votes,0
+Lane,0014 0 GOSHEN,State House,11,REP,Under Votes,132
+Lane,0050 3 EUGENE 223,State House,11,REP,Michael P. Spasaro,242
+Lane,0050 3 EUGENE 223,State House,11,REP,Over Votes,0
+Lane,0050 3 EUGENE 223,State House,11,REP,Under Votes,178
+Lane,0023 1 PLEASANT HILL 1,State House,11,REP,Michael P. Spasaro,531
+Lane,0023 1 PLEASANT HILL 1,State House,11,REP,Over Votes,0
+Lane,0023 1 PLEASANT HILL 1,State House,11,REP,Under Votes,428
+Lane,0079 4 SPRINGFIELD 304,State House,11,REP,Michael P. Spasaro,0
+Lane,0079 4 SPRINGFIELD 304,State House,11,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State House,11,REP,Under Votes,0
+Lane,0078 6 SPRINGFIELD 206,State House,12,REP,Over Votes,0
+Lane,0078 6 SPRINGFIELD 206,State House,12,REP,Under Votes,434
+Lane,0081 4 SPRINGFIELD 504,State House,12,REP,Over Votes,0
+Lane,0081 4 SPRINGFIELD 504,State House,12,REP,Under Votes,435
+Lane,0077 2 SPRINGFIELD 102,State House,12,REP,Over Votes,0
+Lane,0077 2 SPRINGFIELD 102,State House,12,REP,Under Votes,479
+Lane,0002 3 ARMITAGE,State House,12,REP,Over Votes,0
+Lane,0002 3 ARMITAGE,State House,12,REP,Under Votes,162
+Lane,0016 5 GATEWAY,State House,12,REP,Over Votes,0
+Lane,0016 5 GATEWAY,State House,12,REP,Under Votes,133
+Lane,0083 8 SPRINGFIELD 608,State House,12,REP,Over Votes,0
+Lane,0083 8 SPRINGFIELD 608,State House,12,REP,Under Votes,221
+Lane,0080 2 SPRINGFIELD 402,State House,12,REP,Over Votes,0
+Lane,0080 2 SPRINGFIELD 402,State House,12,REP,Under Votes,504
+Lane,0079 4 SPRINGFIELD 304,State House,12,REP,Over Votes,0
+Lane,0079 4 SPRINGFIELD 304,State House,12,REP,Under Votes,425
+Lane,0012 6 GARDEN WAY,State House,12,REP,Over Votes,0
+Lane,0012 6 GARDEN WAY,State House,12,REP,Under Votes,30
+Lane,0082 6 SPRINGFIELD 606,State House,12,REP,Over Votes,0
+Lane,0082 6 SPRINGFIELD 606,State House,12,REP,Under Votes,518
+Lane,0071 9 EUGENE 719,State House,13,REP,Gary Pierpoint,23
+Lane,0071 9 EUGENE 719,State House,13,REP,Over Votes,0
+Lane,0071 9 EUGENE 719,State House,13,REP,Under Votes,27
+Lane,0058 5 EUGENE 435,State House,13,REP,Gary Pierpoint,490
+Lane,0058 5 EUGENE 435,State House,13,REP,Over Votes,0
+Lane,0058 5 EUGENE 435,State House,13,REP,Under Votes,233
+Lane,0056 1 EUGENE 431,State House,13,REP,Gary Pierpoint,111
+Lane,0056 1 EUGENE 431,State House,13,REP,Over Votes,0
+Lane,0056 1 EUGENE 431,State House,13,REP,Under Votes,47
+Lane,0063 3 EUGENE 523,State House,13,REP,Gary Pierpoint,693
+Lane,0063 3 EUGENE 523,State House,13,REP,Over Votes,0
+Lane,0063 3 EUGENE 523,State House,13,REP,Under Votes,284
+Lane,0048 7 EUGENE 117,State House,13,REP,Gary Pierpoint,31
+Lane,0048 7 EUGENE 117,State House,13,REP,Over Votes,0
+Lane,0048 7 EUGENE 117,State House,13,REP,Under Votes,11
+Lane,0029 8 SANTA CLARA 8,State House,13,REP,Gary Pierpoint,232
+Lane,0029 8 SANTA CLARA 8,State House,13,REP,Over Votes,0
+Lane,0029 8 SANTA CLARA 8,State House,13,REP,Under Votes,87
+Lane,0046 7 EUGENE 107,State House,13,REP,Gary Pierpoint,29
+Lane,0046 7 EUGENE 107,State House,13,REP,Over Votes,0
+Lane,0046 7 EUGENE 107,State House,13,REP,Under Votes,10
+Lane,0062 1 EUGENE 511,State House,13,REP,Gary Pierpoint,718
+Lane,0062 1 EUGENE 511,State House,13,REP,Over Votes,0
+Lane,0062 1 EUGENE 511,State House,13,REP,Under Votes,303
+Lane,0061 7 EUGENE 507,State House,13,REP,Gary Pierpoint,291
+Lane,0061 7 EUGENE 507,State House,13,REP,Over Votes,0
+Lane,0061 7 EUGENE 507,State House,13,REP,Under Votes,119
+Lane,0059 9 EUGENE 439,State House,13,REP,Gary Pierpoint,543
+Lane,0059 9 EUGENE 439,State House,13,REP,Over Votes,0
+Lane,0059 9 EUGENE 439,State House,13,REP,Under Votes,323
+Lane,0025 6 RIVER ROAD,State House,13,REP,Gary Pierpoint,355
+Lane,0025 6 RIVER ROAD,State House,13,REP,Over Votes,0
+Lane,0025 6 RIVER ROAD,State House,13,REP,Under Votes,183
+Lane,0072 3 EUGENE 723,State House,13,REP,Gary Pierpoint,220
+Lane,0072 3 EUGENE 723,State House,13,REP,Over Votes,0
+Lane,0072 3 EUGENE 723,State House,13,REP,Under Votes,106
+Lane,0057 3 EUGENE 433,State House,13,REP,Gary Pierpoint,268
+Lane,0057 3 EUGENE 433,State House,13,REP,Over Votes,0
+Lane,0057 3 EUGENE 433,State House,13,REP,Under Votes,154
+Lane,0064 3 EUGENE 613,State House,14,REP,Debi Farr,424
+Lane,0064 3 EUGENE 613,State House,14,REP,Over Votes,1
+Lane,0064 3 EUGENE 613,State House,14,REP,Under Votes,171
+Lane,0001 1 ALVADORE,State House,14,REP,Debi Farr,198
+Lane,0001 1 ALVADORE,State House,14,REP,Over Votes,0
+Lane,0001 1 ALVADORE,State House,14,REP,Under Votes,105
+Lane,0047 9 EUGENE 109,State House,14,REP,Debi Farr,6
+Lane,0047 9 EUGENE 109,State House,14,REP,Over Votes,0
+Lane,0047 9 EUGENE 109,State House,14,REP,Under Votes,3
+Lane,0074 5 EUGENE 805,State House,14,REP,Debi Farr,173
+Lane,0074 5 EUGENE 805,State House,14,REP,Over Votes,0
+Lane,0074 5 EUGENE 805,State House,14,REP,Under Votes,72
+Lane,0028 4 SANTA CLARA 4,State House,14,REP,Debi Farr,459
+Lane,0028 4 SANTA CLARA 4,State House,14,REP,Over Votes,0
+Lane,0028 4 SANTA CLARA 4,State House,14,REP,Under Votes,156
+Lane,0060 5 EUGENE 505,State House,14,REP,Debi Farr,96
+Lane,0060 5 EUGENE 505,State House,14,REP,Over Votes,0
+Lane,0060 5 EUGENE 505,State House,14,REP,Under Votes,27
+Lane,0068 3 EUGENE 713,State House,14,REP,Debi Farr,357
+Lane,0068 3 EUGENE 713,State House,14,REP,Over Votes,0
+Lane,0068 3 EUGENE 713,State House,14,REP,Under Votes,202
+Lane,0008 2 CHESHIRE,State House,14,REP,Debi Farr,429
+Lane,0008 2 CHESHIRE,State House,14,REP,Over Votes,0
+Lane,0008 2 CHESHIRE,State House,14,REP,Under Votes,210
+Lane,0027 1 SANTA CLARA 1,State House,14,REP,Debi Farr,127
+Lane,0027 1 SANTA CLARA 1,State House,14,REP,Over Votes,0
+Lane,0027 1 SANTA CLARA 1,State House,14,REP,Under Votes,77
+Lane,0067 1 EUGENE 711,State House,14,REP,Debi Farr,54
+Lane,0067 1 EUGENE 711,State House,14,REP,Over Votes,0
+Lane,0067 1 EUGENE 711,State House,14,REP,Under Votes,21
+Lane,0045 5 EUGENE 105,State House,14,REP,Debi Farr,34
+Lane,0045 5 EUGENE 105,State House,14,REP,Over Votes,0
+Lane,0045 5 EUGENE 105,State House,14,REP,Under Votes,18
+Lane,0040 0 JUNCTION CITY,State House,14,REP,Debi Farr,289
+Lane,0040 0 JUNCTION CITY,State House,14,REP,Over Votes,0
+Lane,0040 0 JUNCTION CITY,State House,14,REP,Under Votes,90
+Lane,0065 7 EUGENE 617,State House,14,REP,Debi Farr,548
+Lane,0065 7 EUGENE 617,State House,14,REP,Over Votes,0
+Lane,0065 7 EUGENE 617,State House,14,REP,Under Votes,195
+Lane,0073 3 EUGENE 803,State House,14,REP,Debi Farr,105
+Lane,0073 3 EUGENE 803,State House,14,REP,Over Votes,0
+Lane,0073 3 EUGENE 803,State House,14,REP,Under Votes,48
+Lane,0066 3 EUGENE 623,State House,14,REP,Debi Farr,370
+Lane,0066 3 EUGENE 623,State House,14,REP,Over Votes,0
+Lane,0066 3 EUGENE 623,State House,14,REP,Under Votes,159

--- a/lane_2002_general_parser.py
+++ b/lane_2002_general_parser.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# The MIT License (MIT)
+# Copyright (c) 2016 Nick Kocharhook
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+
+import re
+import os
+import sys
+import pdb
+import fileinput
+import unicodecsv
+import pprint
+
+# Configure variables
+county = 'Lane'
+outfile = '20021105__or__general__lane__precinct.csv'
+
+
+headers = ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']
+party_prefixes = ['DEM', 'REP']
+
+office_lookup = {
+	'UNITED STATES PRESIDENT AND VICE PRESIDENT': 'President',
+	'UNITED STATES SENATOR': 'U.S. Senate',
+	'UNITED STATES REP IN CONGRESS': 'U.S. House',
+	'SECRETARY OF STATE': 'Secretary of State',
+	'STATE TREASURER': 'State Treasurer',
+	'ATTORNEY GENERAL': 'Attorney General',
+	'GOVERNOR': 'Governor',
+	'STATE REPRESENTATIVE': 'State House',
+	'STATE SENATOR': 'State Senate'
+}
+
+candidate_lookup = {
+	'WRITE-IN': 'Write-in',
+	'OVER VOTES': 'Over Votes',
+	'UNDER VOTES': 'Under Votes'
+}
+
+
+def main():
+	currentCanvass = ""
+	allCanvasses = []
+	divisionRE = re.compile("\f")
+
+	# read from stdin
+	for line in sys.stdin.readlines():
+		if divisionRE.match(line):
+			previousCanvass = OfficeCanvass(currentCanvass)
+
+			# pdb.set_trace()
+
+			if previousCanvass.office in office_lookup: # exclude lower offices
+				allCanvasses.append(previousCanvass)
+
+			currentCanvass = ""
+		
+		currentCanvass += line
+
+	# printCanvasses(allCanvasses)
+	writeCSV(allCanvasses)
+
+def writeCSV(allCanvasses):
+	def listGet(inList, index, default):
+		try:
+			out = inList[index]
+		except IndexError:
+			out = default
+
+		return out
+
+	with open(outfile, 'wb') as csvfile:
+		w = unicodecsv.writer(csvfile, encoding='utf-8')
+		w.writerow(headers)
+
+		for canvass in allCanvasses:
+			for precinct, results in canvass.results.iteritems():
+				for index, result in enumerate(results):
+					normalisedOffice = office_lookup[canvass.office] # Normalise the office
+					candidate = canvass.candidates[index]
+					party = listGet(canvass.parties, index, "")
+					normalisedCandidate = candidate_lookup.get(candidate, normaliseName(candidate)) # Normalise the candidate
+					normalisedPrecinct = precinct.replace("*", "")
+
+					row = [county, normalisedPrecinct, normalisedOffice, canvass.district,
+							party, normalisedCandidate, result]
+
+					print row
+					w.writerow(row)
+
+def normaliseName(name):
+	name = name.title()
+
+	# Fix "Mcneill"
+	mcRE = re.compile("Mc([a-z])")
+	m = mcRE.search(name)
+	if m:
+		i = m.start(1)
+		name = name[:i] + name[i].swapcase() + name[i+1:]
+
+	# Fix "Eliz Terry Beyer"
+	if "Eliz " in name:
+		name = name.replace("Eliz", "Elizabeth")
+
+	return name
+
+def printCanvasses(allCanvasses):
+	pp = pprint.PrettyPrinter(indent=4)
+
+	for canvass in allCanvasses:
+		print canvass.parties
+		print canvass.office
+		print canvass.district
+		print canvass.candidates
+		pp.pprint(canvass.results)
+		print "====="
+
+
+
+class OfficeCanvass(object):
+	def __init__(self, text):
+		self.lines = text.split('\r\n') # File uses Windows line endings
+		self.header = []
+		self.table = []
+		self.results = {}
+		self.district = ""
+		self.parties = []
+		self.candidates = []
+
+		self.endOfTableRE = re.compile("\*\*\*\*")
+		self.districtRE = re.compile(" (\d\d?)\w\w DISTRICT")
+		self.precintRE = re.compile("\d\d? PRECINCTS")
+		self.partyRE = re.compile("\((\w\w\w)\)")
+		self.pageNumberRE = re.compile("Page Number\s+[\.\d]+")
+
+		self.parseTitle()
+		self.removeTurnoutColumns()
+		self.parseOfficeDistrict()
+		self.populateHeaderAndTable()
+		self.parseHeader()
+		self.parseParties()
+		self.parseResults()
+
+	def __repr__(self):
+		return self.title+self.party+self.office
+
+	def removeTurnoutColumns(self):
+		for index, line in enumerate(self.lines):
+			if len(line) > 50:
+				self.lines[index] = line[:26]+line[43:]
+
+	def parseTitle(self):
+		self.title = self.lines[0].strip()
+		
+	def parseOfficeDistrict(self):
+		self.office = self.title
+
+		m = self.districtRE.search(self.office)
+		if m:
+			self.district = m.group(1)
+			self.office = self.office.replace(m.group(0), "") # Remove district from office
+
+	def parseParties(self):
+		for index, candidate in enumerate(self.candidates):
+			if ',' in candidate:
+				name, party = candidate.split(",")
+				self.candidates[index] = name
+				self.parties.append(party.strip())
+			else:
+				self.parties.append('')
+
+	def populateHeaderAndTable(self):
+		self.header = self.lines[2:26]
+
+		for line in self.lines[26:]:
+			if self.endOfTableRE.search(line):
+				break
+
+			if len(line.strip()):
+				self.table.append(line)
+
+	def parseHeader(self):
+		headerLines = self.header
+
+		# 1. Remove the page number
+		firstLine = headerLines[0]
+		m = self.pageNumberRE.search(firstLine)
+
+		if m:
+			firstLine = firstLine.replace(m.group(0), " "*len(m.group(0)))
+			headerLines[0] = firstLine
+
+		# 2. List candidate columns
+		cols = [35, 41, 47, 53]
+
+		# 3. Make sure all strings are the same length
+		longestString = len(headerLines[0])
+		for i, line in enumerate(headerLines):
+			headerLines[i] = headerLines[i].ljust(longestString)
+
+		# 4. Create 2D array of characters to easily zip()
+		bitmap = []
+		for line in headerLines:
+			bitmap.append(list(line))
+
+		# for aList in bitmap:
+		# 	print aList
+
+		# 5. Read vertical columns of characters as the names, removing unused spaces
+		# print('\n'.join('{}: {}'.format(*k) for k in enumerate(list(headerLines[0]))))
+
+		names = []
+		for col in cols:
+			if longestString >= col:
+				name = "".join(zip(*bitmap)[col])
+				names.append(" ".join(name.split()))
+
+		self.candidates = names
+
+	def parseResults(self):
+		for line in self.table:
+			columns = line.split()
+			candidateCount = len(self.candidates)
+
+			votes = columns[-candidateCount:]
+			del(columns[-candidateCount:])
+			
+			precinct = " ".join(columns)
+			self.results[precinct] = votes
+
+
+
+# Default function is main()
+if __name__ == '__main__':
+	main()

--- a/lane_2004_primary_parser.py
+++ b/lane_2004_primary_parser.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# The MIT License (MIT)
+# Copyright (c) 2016 Nick Kocharhook
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+
+import re
+import os
+import sys
+import pdb
+import fileinput
+import unicodecsv
+import pprint
+
+# Configure variables
+county = 'Lane'
+outfile = '20040518__or__primary__lane__precinct.csv'
+
+
+headers = ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']
+party_prefixes = ['DEM', 'REP']
+
+office_lookup = {
+	'U S PRESIDENT': 'President',
+	'UNITED STATES SENATOR': 'U.S. Senate',
+	'REP IN CONGRESS': 'U.S. House',
+	'SECRETARY OF STATE': 'Secretary of State',
+	'STATE TREASURER': 'State Treasurer',
+	'ATTORNEY GENERAL': 'Attorney General',
+	'GOVERNOR': 'Governor',
+	'STATE REPRESENTATIVE': 'State House',
+	'SENATOR': 'State Senate'
+}
+
+candidate_lookup = {
+	'WRITE-IN': 'Write-in',
+	'OVER VOTES': 'Over Votes',
+	'UNDER VOTES': 'Under Votes'
+}
+
+
+def main():
+	currentCanvass = ""
+	allCanvasses = []
+	divisionRE = re.compile(" PAGE ")
+
+	# read from stdin
+	for line in sys.stdin.readlines():
+		if divisionRE.search(line):
+			canvasses = preprocessPage(currentCanvass)
+
+			for office in canvasses:
+				if office:
+					canvass = OfficeCanvass(office)
+					if canvass.office in office_lookup: # exclude lower offices
+						allCanvasses.append(canvass)
+
+				# pdb.set_trace()
+
+			currentCanvass = ""
+		else:
+			currentCanvass += line
+
+	# printCanvasses(allCanvasses)
+	writeCSV(allCanvasses)
+
+def preprocessPage(page):
+	outCanvasses = [[],[]]
+
+	for line in page.splitlines():
+		columns = line.split("\xb3")
+
+		if len(columns) == 1: # no results info on this line
+			continue
+		if len(columns) == 5: # if there are 2 offices
+			outCanvasses[1].append(columns[0]+columns[3])
+
+		# there will always be at least 1 office
+		outCanvasses[0].append(columns[0]+columns[2])
+
+	if not outCanvasses[1]:
+		del(outCanvasses[1])
+
+	return outCanvasses
+
+
+def writeCSV(allCanvasses):
+	def listGet(inList, index, default):
+		try:
+			out = inList[index]
+		except IndexError:
+			out = default
+
+		return out
+
+	with open(outfile, 'wb') as csvfile:
+		w = unicodecsv.writer(csvfile, encoding='utf-8')
+		w.writerow(headers)
+
+		for canvass in allCanvasses:
+			for precinct, results in canvass.results.iteritems():
+				for index, result in enumerate(results):
+					normalisedOffice = office_lookup[canvass.office] # Normalise the office
+					candidate = canvass.candidates[index]
+					normalisedCandidate = candidate_lookup.get(candidate, candidate.title()) # Normalise the candidate
+
+					row = [county, precinct, normalisedOffice, canvass.district,
+							canvass.party, normalisedCandidate, result]
+
+					print row
+					w.writerow(row)
+
+def printCanvasses(allCanvasses):
+	pp = pprint.PrettyPrinter(indent=4, width=100)
+
+	for canvass in allCanvasses:
+		print canvass.party
+		print canvass.office
+		print canvass.district
+		print canvass.candidates
+		pp.pprint(canvass.results)
+		print "====="
+
+
+
+class OfficeCanvass(object):
+	def __init__(self, lines):
+		# pp = pprint.PrettyPrinter(indent=4)
+		# pp.pprint(lines)
+
+		self.lines = lines #text.split('\r\n') # File uses Windows line endings
+		self.header = []
+		self.table = []
+		self.results = {}
+		self.district = ""
+		self.party = ""
+		self.candidates = []
+
+		self.hyphenRE = re.compile("(\xc4\xc4+)")
+		self.endOfTableRE = re.compile("OFFICIAL CANVASS|TOTALS")
+		self.districtRE = re.compile(",? (\d\d?)\w?\w? DIST(RICT)?")
+		self.precintRE = re.compile("\d\d? PRECINCTS")
+		self.turnoutRE = re.compile("\xb3[^\xb3]+\xb3")
+
+		self.removeTurnoutColumns()
+		self.parseTitle()
+		self.parseOfficePartyDistrict()
+		self.populateHeaderAndTable()
+		self.parseHeader()
+		self.parseResults()
+
+	def __repr__(self):
+		return self.title+self.party+self.office
+
+	def removeTurnoutColumns(self):
+		for index, line in enumerate(self.lines):
+			m = self.turnoutRE.search(line)
+			if m:
+				self.lines[index] = line.replace(m.group(0), "")
+
+	def parseTitle(self):
+		self.title = self.lines[0].strip()
+		
+	def parseOfficePartyDistrict(self):
+		prefix = self.title[0:3]
+		self.office = self.title
+
+		if prefix in party_prefixes:
+			self.party = prefix
+			self.office = self.title[4:] # Remove party from office
+
+		m = self.districtRE.search(self.office)
+		if m:
+			self.district = m.group(1).lstrip("0")
+			self.office = self.office.replace(m.group(0), "") # Remove district from office
+
+	def populateHeaderAndTable(self):
+		inTable = False
+
+		for line in self.lines[2:]:
+			if not inTable:
+				self.header.append(line)
+				if self.hyphenRE.search(line):
+					inTable = True
+			else:
+				if self.endOfTableRE.search(line):
+					break
+
+				if len(line.strip()):
+					self.table.append(line)
+
+	def parseHeader(self):
+		headerLines = self.header
+
+		# 1. Remove the precinct count
+		lastLine = headerLines[-2]
+		m = self.precintRE.search(lastLine)
+
+		if m:
+			lastLine = lastLine.replace(m.group(0), " "*len(m.group(0)))
+			headerLines[-2] = lastLine
+
+		# 2. Find out where the columns are
+		cols = []
+		longestString = len(headerLines[-1])
+
+		for m in self.hyphenRE.finditer(headerLines[-1]):
+			if len(m.group(0)) == 5: # Skip the first set of hyphens
+				for i, g in enumerate(m.groups()):
+					cols.append(m.span(i))
+
+		# 3. Make sure all strings are the same length
+		for i, line in enumerate(headerLines):
+			headerLines[i] = headerLines[i].ljust(longestString)
+
+		# 4. Create 2D array of characters to easily zip()
+		bitmap = []
+		for line in headerLines[:-1]: #skip line of hyphens
+			bitmap.append(list(line))
+
+		# for aList in bitmap:
+		# 	print aList
+
+		# 5. Read vertical columns of characters as the names, removing unused spaces
+		names = []
+		for i, col in enumerate(cols):
+			name = ""
+			for colNum in range(col[0], col[1]):
+				name += "".join(zip(*bitmap)[colNum]) + " "
+			names.append(" ".join(name.split()))
+
+		self.candidates = names
+
+	def parseResults(self):
+		for line in self.table:
+			columns = line.split()
+			candidateCount = len(self.candidates)
+
+			votes = columns[-candidateCount:]
+			del(columns[-candidateCount:])
+			
+			precinct = " ".join(columns)
+			self.results[precinct] = votes
+
+
+
+# Default function is main()
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
NB, the 2002 general data provided "CONST" as the party abbreviation for Oregon's Constitution Party. Since it wasn't 3 letters, I wasn't sure if it should be changed. But I've left it as-is for now.