### PR TITLE
Add precinct-level results for the 2018 general election in Benton County

### DIFF
--- a/2018/counties/20181106__or__general__benton__precinct.csv
+++ b/2018/counties/20181106__or__general__benton__precinct.csv
@@ -1,0 +1,2378 @@
+county,precinct,office,district,party,candidate,votes
+Benton,1,Registered Voters - Total,,,,4179
+Benton,1,Ballots Cast - Total,,,,3381
+Benton,1,Ballots Cast - Blank,,,,3
+Benton,1,U.S. House,4,,Art Robinson,739
+Benton,1,U.S. House,4,,Richard R Jacobson,49
+Benton,1,U.S. House,4,,Mike Beilstein,59
+Benton,1,U.S. House,4,,Peter DeFazio,2439
+Benton,1,U.S. House,4,,Write-In Totals,5
+Benton,1,U.S. House,4,,Overvotes,1
+Benton,1,U.S. House,4,,Undervotes,89
+Benton,1,Governor,,,Aaron Auer,21
+Benton,1,Governor,,,Nick Chen,35
+Benton,1,Governor,,,Kate Brown,2161
+Benton,1,Governor,,,Knute Buehler,1015
+Benton,1,Governor,,,Patrick Starnes,70
+Benton,1,Governor,,,Chris Henry,19
+Benton,1,Governor,,,Write-In Totals,1
+Benton,1,Governor,,,Overvotes,0
+Benton,1,Governor,,,Undervotes,46
+Benton,1,State Senator,8,,Sara A Gelser,2447
+Benton,1,State Senator,8,,Bryan Eggiman,61
+Benton,1,State Senator,8,,Erik S Parks,749
+Benton,1,State Senator,8,,Write-In Totals,4
+Benton,1,State Senator,8,,Overvotes,0
+Benton,1,State Senator,8,,Undervotes,107
+Benton,1,State Representative,16,,Dan Rayfield,2490
+Benton,1,State Representative,16,,Write-In Totals,65
+Benton,1,State Representative,16,,Overvotes,0
+Benton,1,State Representative,16,,Undervotes,813
+Benton,1,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,887
+Benton,1,"County Commissioner, Position 1",,,Erik Gradine,304
+Benton,1,"County Commissioner, Position 1",,,Timothy L Dehne,67
+Benton,1,"County Commissioner, Position 1",,,Pat Malone,1571
+Benton,1,"County Commissioner, Position 1",,,Max Mania,199
+Benton,1,"County Commissioner, Position 1",,,Write-In Totals,10
+Benton,1,"County Commissioner, Position 1",,,Overvotes,0
+Benton,1,"County Commissioner, Position 1",,,Undervotes,330
+Benton,1,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,2167
+Benton,1,"Judge of the Supreme Court, Position 5",,,Write-In Totals,24
+Benton,1,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,1,"Judge of the Supreme Court, Position 5",,,Undervotes,1177
+Benton,1,"Judge of the Court of Appeals, Position 2",,,Bronson D James,2031
+Benton,1,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,18
+Benton,1,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,1,"Judge of the Court of Appeals, Position 2",,,Undervotes,1319
+Benton,1,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,2104
+Benton,1,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,12
+Benton,1,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,1,"Judge of the Court of Appeals, Position 4",,,Undervotes,1252
+Benton,1,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,2064
+Benton,1,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,15
+Benton,1,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,1,"Judge of the Court of Appeals, Position 7",,,Undervotes,1289
+Benton,1,Judge of the Oregon Tax Court,,,Robert Manicke,2060
+Benton,1,Judge of the Oregon Tax Court,,,Write-In Totals,19
+Benton,1,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,1,Judge of the Oregon Tax Court,,,Undervotes,1289
+Benton,1,Sheriff Benton County,,,Scott Jackson,2202
+Benton,1,Sheriff Benton County,,,Write-In Totals,40
+Benton,1,Sheriff Benton County,,,Overvotes,0
+Benton,1,Sheriff Benton County,,,Undervotes,1126
+Benton,1,Mayor City of Corvallis,,,Biff Traber,1651
+Benton,1,Mayor City of Corvallis,,,Dean Codo,133
+Benton,1,Mayor City of Corvallis,,,Riley Doraine,139
+Benton,1,Mayor City of Corvallis,,,Roen Hogg,991
+Benton,1,Mayor City of Corvallis,,,Write-In Totals,22
+Benton,1,Mayor City of Corvallis,,,Overvotes,1
+Benton,1,Mayor City of Corvallis,,,Undervotes,431
+Benton,1,"City Council, Ward 1 City of Corvallis",,,Steve Lee,946
+Benton,1,"City Council, Ward 1 City of Corvallis",,,Jan Napack,1867
+Benton,1,"City Council, Ward 1 City of Corvallis",,,Write-In Totals,13
+Benton,1,"City Council, Ward 1 City of Corvallis",,,Overvotes,0
+Benton,1,"City Council, Ward 1 City of Corvallis",,,Undervotes,542
+Benton,1,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,2056
+Benton,1,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,15
+Benton,1,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,1,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1297
+Benton,1,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1905
+Benton,1,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,20
+Benton,1,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,1,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1443
+Benton,1,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1882
+Benton,1,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,18
+Benton,1,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,1,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1468
+Benton,1,State Measure 102,,,Yes,2149
+Benton,1,State Measure 102,,,No,1099
+Benton,1,State Measure 102,,,Overvotes,1
+Benton,1,State Measure 102,,,Undervotes,119
+Benton,1,State Measure 103,,,Yes,872
+Benton,1,State Measure 103,,,No,2415
+Benton,1,State Measure 103,,,Overvotes,2
+Benton,1,State Measure 103,,,Undervotes,79
+Benton,1,State Measure 104,,,Yes,825
+Benton,1,State Measure 104,,,No,2412
+Benton,1,State Measure 104,,,Overvotes,0
+Benton,1,State Measure 104,,,Undervotes,131
+Benton,1,State Measure 105,,,Yes,715
+Benton,1,State Measure 105,,,No,2579
+Benton,1,State Measure 105,,,Overvotes,2
+Benton,1,State Measure 105,,,Undervotes,72
+Benton,1,State Measure 106,,,Yes,729
+Benton,1,State Measure 106,,,No,2583
+Benton,1,State Measure 106,,,Overvotes,0
+Benton,1,State Measure 106,,,Undervotes,56
+Benton,2,Registered Voters - Total,,,,3162
+Benton,2,Ballots Cast - Total,,,,2131
+Benton,2,Ballots Cast - Blank,,,,2
+Benton,2,U.S. House,4,,Art Robinson,260
+Benton,2,U.S. House,4,,Richard R Jacobson,39
+Benton,2,U.S. House,4,,Mike Beilstein,124
+Benton,2,U.S. House,4,,Peter DeFazio,1639
+Benton,2,U.S. House,4,,Write-In Totals,3
+Benton,2,U.S. House,4,,Overvotes,0
+Benton,2,U.S. House,4,,Undervotes,66
+Benton,2,Governor,,,Aaron Auer,15
+Benton,2,Governor,,,Nick Chen,41
+Benton,2,Governor,,,Kate Brown,1559
+Benton,2,Governor,,,Knute Buehler,357
+Benton,2,Governor,,,Patrick Starnes,70
+Benton,2,Governor,,,Chris Henry,35
+Benton,2,Governor,,,Write-In Totals,6
+Benton,2,Governor,,,Overvotes,0
+Benton,2,Governor,,,Undervotes,32
+Benton,2,State Senator,8,,Sara A Gelser,1691
+Benton,2,State Senator,8,,Bryan Eggiman,49
+Benton,2,State Senator,8,,Erik S Parks,281
+Benton,2,State Senator,8,,Write-In Totals,5
+Benton,2,State Senator,8,,Overvotes,0
+Benton,2,State Senator,8,,Undervotes,89
+Benton,2,State Representative,16,,Dan Rayfield,1679
+Benton,2,State Representative,16,,Write-In Totals,46
+Benton,2,State Representative,16,,Overvotes,0
+Benton,2,State Representative,16,,Undervotes,390
+Benton,2,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,584
+Benton,2,"County Commissioner, Position 1",,,Erik Gradine,139
+Benton,2,"County Commissioner, Position 1",,,Timothy L Dehne,104
+Benton,2,"County Commissioner, Position 1",,,Pat Malone,962
+Benton,2,"County Commissioner, Position 1",,,Max Mania,159
+Benton,2,"County Commissioner, Position 1",,,Write-In Totals,9
+Benton,2,"County Commissioner, Position 1",,,Overvotes,0
+Benton,2,"County Commissioner, Position 1",,,Undervotes,158
+Benton,2,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1398
+Benton,2,"Judge of the Supreme Court, Position 5",,,Write-In Totals,30
+Benton,2,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,2,"Judge of the Supreme Court, Position 5",,,Undervotes,687
+Benton,2,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1313
+Benton,2,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,28
+Benton,2,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,2,"Judge of the Court of Appeals, Position 2",,,Undervotes,774
+Benton,2,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1360
+Benton,2,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,27
+Benton,2,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,2,"Judge of the Court of Appeals, Position 4",,,Undervotes,728
+Benton,2,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1338
+Benton,2,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,32
+Benton,2,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,2,"Judge of the Court of Appeals, Position 7",,,Undervotes,745
+Benton,2,Judge of the Oregon Tax Court,,,Robert Manicke,1332
+Benton,2,Judge of the Oregon Tax Court,,,Write-In Totals,22
+Benton,2,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,2,Judge of the Oregon Tax Court,,,Undervotes,761
+Benton,2,Sheriff Benton County,,,Scott Jackson,1329
+Benton,2,Sheriff Benton County,,,Write-In Totals,30
+Benton,2,Sheriff Benton County,,,Overvotes,0
+Benton,2,Sheriff Benton County,,,Undervotes,756
+Benton,2,Mayor City of Corvallis,,,Biff Traber,871
+Benton,2,Mayor City of Corvallis,,,Dean Codo,121
+Benton,2,Mayor City of Corvallis,,,Riley Doraine,159
+Benton,2,Mayor City of Corvallis,,,Roen Hogg,652
+Benton,2,Mayor City of Corvallis,,,Write-In Totals,23
+Benton,2,Mayor City of Corvallis,,,Overvotes,0
+Benton,2,Mayor City of Corvallis,,,Undervotes,289
+Benton,2,"City Council, Ward 2 City of Corvallis",,,Catherine M Mater,695
+Benton,2,"City Council, Ward 2 City of Corvallis",,,Charles F Maughan,991
+Benton,2,"City Council, Ward 2 City of Corvallis",,,Write-In Totals,20
+Benton,2,"City Council, Ward 2 City of Corvallis",,,Overvotes,0
+Benton,2,"City Council, Ward 2 City of Corvallis",,,Undervotes,409
+Benton,2,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1307
+Benton,2,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,2,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,2,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,796
+Benton,2,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1259
+Benton,2,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,14
+Benton,2,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,2,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,842
+Benton,2,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1248
+Benton,2,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,17
+Benton,2,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,2,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,850
+Benton,2,State Measure 102,,,Yes,1596
+Benton,2,State Measure 102,,,No,430
+Benton,2,State Measure 102,,,Overvotes,0
+Benton,2,State Measure 102,,,Undervotes,89
+Benton,2,State Measure 103,,,Yes,555
+Benton,2,State Measure 103,,,No,1493
+Benton,2,State Measure 103,,,Overvotes,8
+Benton,2,State Measure 103,,,Undervotes,59
+Benton,2,State Measure 104,,,Yes,460
+Benton,2,State Measure 104,,,No,1547
+Benton,2,State Measure 104,,,Overvotes,0
+Benton,2,State Measure 104,,,Undervotes,108
+Benton,2,State Measure 105,,,Yes,310
+Benton,2,State Measure 105,,,No,1762
+Benton,2,State Measure 105,,,Overvotes,0
+Benton,2,State Measure 105,,,Undervotes,43
+Benton,2,State Measure 106,,,Yes,312
+Benton,2,State Measure 106,,,No,1775
+Benton,2,State Measure 106,,,Overvotes,0
+Benton,2,State Measure 106,,,Undervotes,28
+Benton,3,Registered Voters - Total,,,,4079
+Benton,3,Ballots Cast - Total,,,,3125
+Benton,3,Ballots Cast - Blank,,,,0
+Benton,3,U.S. House,4,,Art Robinson,510
+Benton,3,U.S. House,4,,Richard R Jacobson,42
+Benton,3,U.S. House,4,,Mike Beilstein,142
+Benton,3,U.S. House,4,,Peter DeFazio,2380
+Benton,3,U.S. House,4,,Write-In Totals,2
+Benton,3,U.S. House,4,,Overvotes,0
+Benton,3,U.S. House,4,,Undervotes,49
+Benton,3,Governor,,,Aaron Auer,20
+Benton,3,Governor,,,Nick Chen,60
+Benton,3,Governor,,,Kate Brown,2173
+Benton,3,Governor,,,Knute Buehler,694
+Benton,3,Governor,,,Patrick Starnes,105
+Benton,3,Governor,,,Chris Henry,22
+Benton,3,Governor,,,Write-In Totals,4
+Benton,3,Governor,,,Overvotes,0
+Benton,3,Governor,,,Undervotes,39
+Benton,3,State Senator,8,,Sara A Gelser,2424
+Benton,3,State Senator,8,,Bryan Eggiman,67
+Benton,3,State Senator,8,,Erik S Parks,550
+Benton,3,State Senator,8,,Write-In Totals,1
+Benton,3,State Senator,8,,Overvotes,0
+Benton,3,State Senator,8,,Undervotes,75
+Benton,3,State Representative,16,,Dan Rayfield,2392
+Benton,3,State Representative,16,,Write-In Totals,53
+Benton,3,State Representative,16,,Overvotes,0
+Benton,3,State Representative,16,,Undervotes,672
+Benton,3,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,1053
+Benton,3,"County Commissioner, Position 1",,,Erik Gradine,258
+Benton,3,"County Commissioner, Position 1",,,Timothy L Dehne,106
+Benton,3,"County Commissioner, Position 1",,,Pat Malone,1264
+Benton,3,"County Commissioner, Position 1",,,Max Mania,224
+Benton,3,"County Commissioner, Position 1",,,Write-In Totals,5
+Benton,3,"County Commissioner, Position 1",,,Overvotes,2
+Benton,3,"County Commissioner, Position 1",,,Undervotes,205
+Benton,3,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,2010
+Benton,3,"Judge of the Supreme Court, Position 5",,,Write-In Totals,23
+Benton,3,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,3,"Judge of the Supreme Court, Position 5",,,Undervotes,1084
+Benton,3,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1859
+Benton,3,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,30
+Benton,3,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,3,"Judge of the Court of Appeals, Position 2",,,Undervotes,1228
+Benton,3,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1935
+Benton,3,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,23
+Benton,3,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,3,"Judge of the Court of Appeals, Position 4",,,Undervotes,1159
+Benton,3,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1882
+Benton,3,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,29
+Benton,3,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,3,"Judge of the Court of Appeals, Position 7",,,Undervotes,1206
+Benton,3,Judge of the Oregon Tax Court,,,Robert Manicke,1886
+Benton,3,Judge of the Oregon Tax Court,,,Write-In Totals,23
+Benton,3,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,3,Judge of the Oregon Tax Court,,,Undervotes,1208
+Benton,3,Sheriff Benton County,,,Scott Jackson,1936
+Benton,3,Sheriff Benton County,,,Write-In Totals,47
+Benton,3,Sheriff Benton County,,,Overvotes,0
+Benton,3,Sheriff Benton County,,,Undervotes,1134
+Benton,3,Mayor City of Corvallis,,,Biff Traber,1532
+Benton,3,Mayor City of Corvallis,,,Dean Codo,164
+Benton,3,Mayor City of Corvallis,,,Riley Doraine,182
+Benton,3,Mayor City of Corvallis,,,Roen Hogg,878
+Benton,3,Mayor City of Corvallis,,,Write-In Totals,19
+Benton,3,Mayor City of Corvallis,,,Overvotes,0
+Benton,3,Mayor City of Corvallis,,,Undervotes,342
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Hyatt Lytle,1765
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Mika Goodwin,376
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Rachell B Hoffman,415
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Write-In Totals,17
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Overvotes,1
+Benton,3,"City Council, Ward 3 City of Corvallis",,,Undervotes,543
+Benton,3,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1888
+Benton,3,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,17
+Benton,3,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,3,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1212
+Benton,3,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1788
+Benton,3,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,19
+Benton,3,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,3,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1310
+Benton,3,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1770
+Benton,3,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,21
+Benton,3,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,3,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1326
+Benton,3,State Measure 102,,,Yes,2127
+Benton,3,State Measure 102,,,No,890
+Benton,3,State Measure 102,,,Overvotes,0
+Benton,3,State Measure 102,,,Undervotes,100
+Benton,3,State Measure 103,,,Yes,808
+Benton,3,State Measure 103,,,No,2241
+Benton,3,State Measure 103,,,Overvotes,1
+Benton,3,State Measure 103,,,Undervotes,67
+Benton,3,State Measure 104,,,Yes,718
+Benton,3,State Measure 104,,,No,2285
+Benton,3,State Measure 104,,,Overvotes,3
+Benton,3,State Measure 104,,,Undervotes,111
+Benton,3,State Measure 105,,,Yes,543
+Benton,3,State Measure 105,,,No,2520
+Benton,3,State Measure 105,,,Overvotes,0
+Benton,3,State Measure 105,,,Undervotes,54
+Benton,3,State Measure 106,,,Yes,588
+Benton,3,State Measure 106,,,No,2489
+Benton,3,State Measure 106,,,Overvotes,1
+Benton,3,State Measure 106,,,Undervotes,39
+Benton,4,Registered Voters - Total,,,,2037
+Benton,4,Ballots Cast - Total,,,,1426
+Benton,4,Ballots Cast - Blank,,,,0
+Benton,4,U.S. House,4,,Art Robinson,183
+Benton,4,U.S. House,4,,Richard R Jacobson,22
+Benton,4,U.S. House,4,,Mike Beilstein,58
+Benton,4,U.S. House,4,,Peter DeFazio,1132
+Benton,4,U.S. House,4,,Write-In Totals,3
+Benton,4,U.S. House,4,,Overvotes,0
+Benton,4,U.S. House,4,,Undervotes,28
+Benton,4,Governor,,,Aaron Auer,6
+Benton,4,Governor,,,Nick Chen,29
+Benton,4,Governor,,,Kate Brown,1054
+Benton,4,Governor,,,Knute Buehler,276
+Benton,4,Governor,,,Patrick Starnes,30
+Benton,4,Governor,,,Chris Henry,5
+Benton,4,Governor,,,Write-In Totals,2
+Benton,4,Governor,,,Overvotes,0
+Benton,4,Governor,,,Undervotes,15
+Benton,4,State Senator,8,,Sara A Gelser,1147
+Benton,4,State Senator,8,,Bryan Eggiman,27
+Benton,4,State Senator,8,,Erik S Parks,196
+Benton,4,State Senator,8,,Write-In Totals,1
+Benton,4,State Senator,8,,Overvotes,0
+Benton,4,State Senator,8,,Undervotes,46
+Benton,4,State Representative,16,,Dan Rayfield,1132
+Benton,4,State Representative,16,,Write-In Totals,25
+Benton,4,State Representative,16,,Overvotes,0
+Benton,4,State Representative,16,,Undervotes,260
+Benton,4,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,318
+Benton,4,"County Commissioner, Position 1",,,Erik Gradine,95
+Benton,4,"County Commissioner, Position 1",,,Timothy L Dehne,39
+Benton,4,"County Commissioner, Position 1",,,Pat Malone,748
+Benton,4,"County Commissioner, Position 1",,,Max Mania,100
+Benton,4,"County Commissioner, Position 1",,,Write-In Totals,3
+Benton,4,"County Commissioner, Position 1",,,Overvotes,0
+Benton,4,"County Commissioner, Position 1",,,Undervotes,114
+Benton,4,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,969
+Benton,4,"Judge of the Supreme Court, Position 5",,,Write-In Totals,12
+Benton,4,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,4,"Judge of the Supreme Court, Position 5",,,Undervotes,436
+Benton,4,"Judge of the Court of Appeals, Position 2",,,Bronson D James,926
+Benton,4,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,13
+Benton,4,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,4,"Judge of the Court of Appeals, Position 2",,,Undervotes,478
+Benton,4,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,955
+Benton,4,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,9
+Benton,4,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,4,"Judge of the Court of Appeals, Position 4",,,Undervotes,453
+Benton,4,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,939
+Benton,4,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,9
+Benton,4,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,4,"Judge of the Court of Appeals, Position 7",,,Undervotes,469
+Benton,4,Judge of the Oregon Tax Court,,,Robert Manicke,938
+Benton,4,Judge of the Oregon Tax Court,,,Write-In Totals,9
+Benton,4,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,4,Judge of the Oregon Tax Court,,,Undervotes,470
+Benton,4,Sheriff Benton County,,,Scott Jackson,948
+Benton,4,Sheriff Benton County,,,Write-In Totals,21
+Benton,4,Sheriff Benton County,,,Overvotes,0
+Benton,4,Sheriff Benton County,,,Undervotes,448
+Benton,4,Mayor City of Corvallis,,,Biff Traber,639
+Benton,4,Mayor City of Corvallis,,,Dean Codo,81
+Benton,4,Mayor City of Corvallis,,,Riley Doraine,105
+Benton,4,Mayor City of Corvallis,,,Roen Hogg,359
+Benton,4,Mayor City of Corvallis,,,Write-In Totals,14
+Benton,4,Mayor City of Corvallis,,,Overvotes,0
+Benton,4,Mayor City of Corvallis,,,Undervotes,219
+Benton,4,"City Council, Ward 4 City of Corvallis",,,Barbara Bull,1002
+Benton,4,"City Council, Ward 4 City of Corvallis",,,Write-In Totals,21
+Benton,4,"City Council, Ward 4 City of Corvallis",,,Overvotes,0
+Benton,4,"City Council, Ward 4 City of Corvallis",,,Undervotes,394
+Benton,4,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,911
+Benton,4,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,9
+Benton,4,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,4,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,497
+Benton,4,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,879
+Benton,4,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,4,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,4,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,527
+Benton,4,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,866
+Benton,4,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,13
+Benton,4,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,4,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,538
+Benton,4,State Measure 102,,,Yes,1076
+Benton,4,State Measure 102,,,No,292
+Benton,4,State Measure 102,,,Overvotes,0
+Benton,4,State Measure 102,,,Undervotes,49
+Benton,4,State Measure 103,,,Yes,366
+Benton,4,State Measure 103,,,No,1014
+Benton,4,State Measure 103,,,Overvotes,1
+Benton,4,State Measure 103,,,Undervotes,36
+Benton,4,State Measure 104,,,Yes,305
+Benton,4,State Measure 104,,,No,1046
+Benton,4,State Measure 104,,,Overvotes,0
+Benton,4,State Measure 104,,,Undervotes,66
+Benton,4,State Measure 105,,,Yes,214
+Benton,4,State Measure 105,,,No,1180
+Benton,4,State Measure 105,,,Overvotes,0
+Benton,4,State Measure 105,,,Undervotes,23
+Benton,4,State Measure 106,,,Yes,207
+Benton,4,State Measure 106,,,No,1183
+Benton,4,State Measure 106,,,Overvotes,2
+Benton,4,State Measure 106,,,Undervotes,25
+Benton,5,Registered Voters - Total,,,,2998
+Benton,5,Ballots Cast - Total,,,,2082
+Benton,5,Ballots Cast - Blank,,,,1
+Benton,5,U.S. House,4,,Art Robinson,200
+Benton,5,U.S. House,4,,Richard R Jacobson,24
+Benton,5,U.S. House,4,,Mike Beilstein,90
+Benton,5,U.S. House,4,,Peter DeFazio,1712
+Benton,5,U.S. House,4,,Write-In Totals,3
+Benton,5,U.S. House,4,,Overvotes,0
+Benton,5,U.S. House,4,,Undervotes,53
+Benton,5,Governor,,,Aaron Auer,10
+Benton,5,Governor,,,Nick Chen,44
+Benton,5,Governor,,,Kate Brown,1601
+Benton,5,Governor,,,Knute Buehler,304
+Benton,5,Governor,,,Patrick Starnes,50
+Benton,5,Governor,,,Chris Henry,15
+Benton,5,Governor,,,Write-In Totals,5
+Benton,5,Governor,,,Overvotes,0
+Benton,5,Governor,,,Undervotes,38
+Benton,5,State Senator,8,,Sara A Gelser,1747
+Benton,5,State Senator,8,,Bryan Eggiman,45
+Benton,5,State Senator,8,,Erik S Parks,205
+Benton,5,State Senator,8,,Write-In Totals,4
+Benton,5,State Senator,8,,Overvotes,0
+Benton,5,State Senator,8,,Undervotes,66
+Benton,5,State Representative,16,,Dan Rayfield,1698
+Benton,5,State Representative,16,,Write-In Totals,26
+Benton,5,State Representative,16,,Overvotes,0
+Benton,5,State Representative,16,,Undervotes,343
+Benton,5,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,593
+Benton,5,"County Commissioner, Position 1",,,Erik Gradine,98
+Benton,5,"County Commissioner, Position 1",,,Timothy L Dehne,89
+Benton,5,"County Commissioner, Position 1",,,Pat Malone,990
+Benton,5,"County Commissioner, Position 1",,,Max Mania,139
+Benton,5,"County Commissioner, Position 1",,,Write-In Totals,6
+Benton,5,"County Commissioner, Position 1",,,Overvotes,0
+Benton,5,"County Commissioner, Position 1",,,Undervotes,152
+Benton,5,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1401
+Benton,5,"Judge of the Supreme Court, Position 5",,,Write-In Totals,17
+Benton,5,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,5,"Judge of the Supreme Court, Position 5",,,Undervotes,649
+Benton,5,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1307
+Benton,5,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,20
+Benton,5,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,5,"Judge of the Court of Appeals, Position 2",,,Undervotes,740
+Benton,5,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1365
+Benton,5,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,15
+Benton,5,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,5,"Judge of the Court of Appeals, Position 4",,,Undervotes,687
+Benton,5,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1334
+Benton,5,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,14
+Benton,5,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,5,"Judge of the Court of Appeals, Position 7",,,Undervotes,719
+Benton,5,Judge of the Oregon Tax Court,,,Robert Manicke,1323
+Benton,5,Judge of the Oregon Tax Court,,,Write-In Totals,14
+Benton,5,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,5,Judge of the Oregon Tax Court,,,Undervotes,730
+Benton,5,Sheriff Benton County,,,Scott Jackson,1310
+Benton,5,Sheriff Benton County,,,Write-In Totals,34
+Benton,5,Sheriff Benton County,,,Overvotes,0
+Benton,5,Sheriff Benton County,,,Undervotes,723
+Benton,5,Mayor City of Corvallis,,,Biff Traber,1042
+Benton,5,Mayor City of Corvallis,,,Dean Codo,93
+Benton,5,Mayor City of Corvallis,,,Riley Doraine,135
+Benton,5,Mayor City of Corvallis,,,Roen Hogg,480
+Benton,5,Mayor City of Corvallis,,,Write-In Totals,20
+Benton,5,Mayor City of Corvallis,,,Overvotes,0
+Benton,5,Mayor City of Corvallis,,,Undervotes,297
+Benton,5,"City Council, Ward 5 City of Corvallis",,,Paige Kreisman,601
+Benton,5,"City Council, Ward 5 City of Corvallis",,,Charlyn Ellis,1019
+Benton,5,"City Council, Ward 5 City of Corvallis",,,Write-In Totals,9
+Benton,5,"City Council, Ward 5 City of Corvallis",,,Overvotes,2
+Benton,5,"City Council, Ward 5 City of Corvallis",,,Undervotes,436
+Benton,5,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1295
+Benton,5,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,5,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,5,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,760
+Benton,5,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1222
+Benton,5,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,5,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,5,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,834
+Benton,5,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1212
+Benton,5,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,5,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,5,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,844
+Benton,5,State Measure 102,,,Yes,1613
+Benton,5,State Measure 102,,,No,385
+Benton,5,State Measure 102,,,Overvotes,1
+Benton,5,State Measure 102,,,Undervotes,68
+Benton,5,State Measure 103,,,Yes,469
+Benton,5,State Measure 103,,,No,1554
+Benton,5,State Measure 103,,,Overvotes,1
+Benton,5,State Measure 103,,,Undervotes,43
+Benton,5,State Measure 104,,,Yes,401
+Benton,5,State Measure 104,,,No,1570
+Benton,5,State Measure 104,,,Overvotes,0
+Benton,5,State Measure 104,,,Undervotes,96
+Benton,5,State Measure 105,,,Yes,234
+Benton,5,State Measure 105,,,No,1799
+Benton,5,State Measure 105,,,Overvotes,0
+Benton,5,State Measure 105,,,Undervotes,34
+Benton,5,State Measure 106,,,Yes,221
+Benton,5,State Measure 106,,,No,1813
+Benton,5,State Measure 106,,,Overvotes,1
+Benton,5,State Measure 106,,,Undervotes,32
+Benton,6,Registered Voters - Total,,,,3898
+Benton,6,Ballots Cast - Total,,,,2890
+Benton,6,Ballots Cast - Blank,,,,1
+Benton,6,U.S. House,4,,Art Robinson,437
+Benton,6,U.S. House,4,,Richard R Jacobson,35
+Benton,6,U.S. House,4,,Mike Beilstein,93
+Benton,6,U.S. House,4,,Peter DeFazio,2264
+Benton,6,U.S. House,4,,Write-In Totals,2
+Benton,6,U.S. House,4,,Overvotes,1
+Benton,6,U.S. House,4,,Undervotes,58
+Benton,6,Governor,,,Aaron Auer,24
+Benton,6,Governor,,,Nick Chen,60
+Benton,6,Governor,,,Kate Brown,2063
+Benton,6,Governor,,,Knute Buehler,600
+Benton,6,Governor,,,Patrick Starnes,69
+Benton,6,Governor,,,Chris Henry,17
+Benton,6,Governor,,,Write-In Totals,8
+Benton,6,Governor,,,Overvotes,1
+Benton,6,Governor,,,Undervotes,40
+Benton,6,State Senator,8,,Sara A Gelser,2274
+Benton,6,State Senator,8,,Bryan Eggiman,57
+Benton,6,State Senator,8,,Erik S Parks,454
+Benton,6,State Senator,8,,Write-In Totals,2
+Benton,6,State Senator,8,,Overvotes,1
+Benton,6,State Senator,8,,Undervotes,94
+Benton,6,State Representative,16,,Dan Rayfield,2236
+Benton,6,State Representative,16,,Write-In Totals,64
+Benton,6,State Representative,16,,Overvotes,0
+Benton,6,State Representative,16,,Undervotes,582
+Benton,6,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,822
+Benton,6,"County Commissioner, Position 1",,,Erik Gradine,168
+Benton,6,"County Commissioner, Position 1",,,Timothy L Dehne,75
+Benton,6,"County Commissioner, Position 1",,,Pat Malone,1367
+Benton,6,"County Commissioner, Position 1",,,Max Mania,218
+Benton,6,"County Commissioner, Position 1",,,Write-In Totals,7
+Benton,6,"County Commissioner, Position 1",,,Overvotes,2
+Benton,6,"County Commissioner, Position 1",,,Undervotes,223
+Benton,6,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1896
+Benton,6,"Judge of the Supreme Court, Position 5",,,Write-In Totals,26
+Benton,6,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,6,"Judge of the Supreme Court, Position 5",,,Undervotes,960
+Benton,6,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1770
+Benton,6,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,30
+Benton,6,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,6,"Judge of the Court of Appeals, Position 2",,,Undervotes,1082
+Benton,6,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1833
+Benton,6,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,21
+Benton,6,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,6,"Judge of the Court of Appeals, Position 4",,,Undervotes,1028
+Benton,6,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1804
+Benton,6,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,29
+Benton,6,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,6,"Judge of the Court of Appeals, Position 7",,,Undervotes,1049
+Benton,6,Judge of the Oregon Tax Court,,,Robert Manicke,1788
+Benton,6,Judge of the Oregon Tax Court,,,Write-In Totals,26
+Benton,6,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,6,Judge of the Oregon Tax Court,,,Undervotes,1068
+Benton,6,Sheriff Benton County,,,Scott Jackson,1830
+Benton,6,Sheriff Benton County,,,Write-In Totals,46
+Benton,6,Sheriff Benton County,,,Overvotes,0
+Benton,6,Sheriff Benton County,,,Undervotes,1006
+Benton,6,Mayor City of Corvallis,,,Biff Traber,1584
+Benton,6,Mayor City of Corvallis,,,Dean Codo,146
+Benton,6,Mayor City of Corvallis,,,Riley Doraine,159
+Benton,6,Mayor City of Corvallis,,,Roen Hogg,612
+Benton,6,Mayor City of Corvallis,,,Write-In Totals,20
+Benton,6,Mayor City of Corvallis,,,Overvotes,1
+Benton,6,Mayor City of Corvallis,,,Undervotes,360
+Benton,6,"City Council, Ward 6 City of Corvallis",,,Nancy V Wyse,1972
+Benton,6,"City Council, Ward 6 City of Corvallis",,,Write-In Totals,35
+Benton,6,"City Council, Ward 6 City of Corvallis",,,Overvotes,0
+Benton,6,"City Council, Ward 6 City of Corvallis",,,Undervotes,875
+Benton,6,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1773
+Benton,6,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,19
+Benton,6,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,6,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1090
+Benton,6,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1700
+Benton,6,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,19
+Benton,6,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,6,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1163
+Benton,6,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1680
+Benton,6,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,21
+Benton,6,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,6,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1181
+Benton,6,State Measure 102,,,Yes,2049
+Benton,6,State Measure 102,,,No,740
+Benton,6,State Measure 102,,,Overvotes,2
+Benton,6,State Measure 102,,,Undervotes,91
+Benton,6,State Measure 103,,,Yes,663
+Benton,6,State Measure 103,,,No,2157
+Benton,6,State Measure 103,,,Overvotes,4
+Benton,6,State Measure 103,,,Undervotes,58
+Benton,6,State Measure 104,,,Yes,587
+Benton,6,State Measure 104,,,No,2206
+Benton,6,State Measure 104,,,Overvotes,0
+Benton,6,State Measure 104,,,Undervotes,89
+Benton,6,State Measure 105,,,Yes,471
+Benton,6,State Measure 105,,,No,2367
+Benton,6,State Measure 105,,,Overvotes,2
+Benton,6,State Measure 105,,,Undervotes,42
+Benton,6,State Measure 106,,,Yes,539
+Benton,6,State Measure 106,,,No,2311
+Benton,6,State Measure 106,,,Overvotes,1
+Benton,6,State Measure 106,,,Undervotes,31
+Benton,7,Registered Voters - Total,,,,4261
+Benton,7,Ballots Cast - Total,,,,3582
+Benton,7,Ballots Cast - Blank,,,,0
+Benton,7,U.S. House,4,,Art Robinson,444
+Benton,7,U.S. House,4,,Richard R Jacobson,35
+Benton,7,U.S. House,4,,Mike Beilstein,80
+Benton,7,U.S. House,4,,Peter DeFazio,2967
+Benton,7,U.S. House,4,,Write-In Totals,6
+Benton,7,U.S. House,4,,Overvotes,0
+Benton,7,U.S. House,4,,Undervotes,50
+Benton,7,Governor,,,Aaron Auer,10
+Benton,7,Governor,,,Nick Chen,38
+Benton,7,Governor,,,Kate Brown,2755
+Benton,7,Governor,,,Knute Buehler,640
+Benton,7,Governor,,,Patrick Starnes,51
+Benton,7,Governor,,,Chris Henry,12
+Benton,7,Governor,,,Write-In Totals,2
+Benton,7,Governor,,,Overvotes,0
+Benton,7,Governor,,,Undervotes,47
+Benton,7,State Senator,8,,Sara A Gelser,2938
+Benton,7,State Senator,8,,Bryan Eggiman,49
+Benton,7,State Senator,8,,Erik S Parks,482
+Benton,7,State Senator,8,,Write-In Totals,4
+Benton,7,State Senator,8,,Overvotes,0
+Benton,7,State Senator,8,,Undervotes,82
+Benton,7,State Representative,16,,Dan Rayfield,2865
+Benton,7,State Representative,16,,Write-In Totals,49
+Benton,7,State Representative,16,,Overvotes,0
+Benton,7,State Representative,16,,Undervotes,641
+Benton,7,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,1071
+Benton,7,"County Commissioner, Position 1",,,Erik Gradine,211
+Benton,7,"County Commissioner, Position 1",,,Timothy L Dehne,75
+Benton,7,"County Commissioner, Position 1",,,Pat Malone,1754
+Benton,7,"County Commissioner, Position 1",,,Max Mania,202
+Benton,7,"County Commissioner, Position 1",,,Write-In Totals,6
+Benton,7,"County Commissioner, Position 1",,,Overvotes,2
+Benton,7,"County Commissioner, Position 1",,,Undervotes,234
+Benton,7,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,2367
+Benton,7,"Judge of the Supreme Court, Position 5",,,Write-In Totals,21
+Benton,7,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,7,"Judge of the Supreme Court, Position 5",,,Undervotes,1167
+Benton,7,"Judge of the Court of Appeals, Position 2",,,Bronson D James,2200
+Benton,7,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,23
+Benton,7,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,7,"Judge of the Court of Appeals, Position 2",,,Undervotes,1332
+Benton,7,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,2289
+Benton,7,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,18
+Benton,7,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,7,"Judge of the Court of Appeals, Position 4",,,Undervotes,1248
+Benton,7,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,2259
+Benton,7,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,19
+Benton,7,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,7,"Judge of the Court of Appeals, Position 7",,,Undervotes,1277
+Benton,7,Judge of the Oregon Tax Court,,,Robert Manicke,2255
+Benton,7,Judge of the Oregon Tax Court,,,Write-In Totals,16
+Benton,7,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,7,Judge of the Oregon Tax Court,,,Undervotes,1284
+Benton,7,Sheriff Benton County,,,Scott Jackson,2297
+Benton,7,Sheriff Benton County,,,Write-In Totals,39
+Benton,7,Sheriff Benton County,,,Overvotes,0
+Benton,7,Sheriff Benton County,,,Undervotes,1219
+Benton,7,Mayor City of Corvallis,,,Biff Traber,1891
+Benton,7,Mayor City of Corvallis,,,Dean Codo,99
+Benton,7,Mayor City of Corvallis,,,Riley Doraine,113
+Benton,7,Mayor City of Corvallis,,,Roen Hogg,1091
+Benton,7,Mayor City of Corvallis,,,Write-In Totals,19
+Benton,7,Mayor City of Corvallis,,,Overvotes,0
+Benton,7,Mayor City of Corvallis,,,Undervotes,342
+Benton,7,"City Council, Ward 7 City of Corvallis",,,Bill Glassmire,2535
+Benton,7,"City Council, Ward 7 City of Corvallis",,,Write-In Totals,38
+Benton,7,"City Council, Ward 7 City of Corvallis",,,Overvotes,0
+Benton,7,"City Council, Ward 7 City of Corvallis",,,Undervotes,982
+Benton,7,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,2229
+Benton,7,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,15
+Benton,7,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,7,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1311
+Benton,7,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,2093
+Benton,7,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,7,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,7,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1450
+Benton,7,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,2069
+Benton,7,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,7,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,7,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1474
+Benton,7,State Measure 102,,,Yes,2585
+Benton,7,State Measure 102,,,No,883
+Benton,7,State Measure 102,,,Overvotes,0
+Benton,7,State Measure 102,,,Undervotes,87
+Benton,7,State Measure 103,,,Yes,614
+Benton,7,State Measure 103,,,No,2886
+Benton,7,State Measure 103,,,Overvotes,3
+Benton,7,State Measure 103,,,Undervotes,52
+Benton,7,State Measure 104,,,Yes,616
+Benton,7,State Measure 104,,,No,2849
+Benton,7,State Measure 104,,,Overvotes,0
+Benton,7,State Measure 104,,,Undervotes,90
+Benton,7,State Measure 105,,,Yes,492
+Benton,7,State Measure 105,,,No,3023
+Benton,7,State Measure 105,,,Overvotes,0
+Benton,7,State Measure 105,,,Undervotes,40
+Benton,7,State Measure 106,,,Yes,453
+Benton,7,State Measure 106,,,No,3068
+Benton,7,State Measure 106,,,Overvotes,0
+Benton,7,State Measure 106,,,Undervotes,34
+Benton,8,Registered Voters - Total,,,,4503
+Benton,8,Ballots Cast - Total,,,,3773
+Benton,8,Ballots Cast - Blank,,,,0
+Benton,8,U.S. House,4,,Art Robinson,716
+Benton,8,U.S. House,4,,Richard R Jacobson,50
+Benton,8,U.S. House,4,,Mike Beilstein,63
+Benton,8,U.S. House,4,,Peter DeFazio,2862
+Benton,8,U.S. House,4,,Write-In Totals,5
+Benton,8,U.S. House,4,,Overvotes,1
+Benton,8,U.S. House,4,,Undervotes,76
+Benton,8,Governor,,,Aaron Auer,16
+Benton,8,Governor,,,Nick Chen,42
+Benton,8,Governor,,,Kate Brown,2546
+Benton,8,Governor,,,Knute Buehler,1032
+Benton,8,Governor,,,Patrick Starnes,60
+Benton,8,Governor,,,Chris Henry,20
+Benton,8,Governor,,,Write-In Totals,2
+Benton,8,Governor,,,Overvotes,0
+Benton,8,Governor,,,Undervotes,44
+Benton,8,State Senator,8,,Sara A Gelser,2836
+Benton,8,State Senator,8,,Bryan Eggiman,48
+Benton,8,State Senator,8,,Erik S Parks,766
+Benton,8,State Senator,8,,Write-In Totals,5
+Benton,8,State Senator,8,,Overvotes,0
+Benton,8,State Senator,8,,Undervotes,107
+Benton,8,State Representative,16,,Dan Rayfield,2857
+Benton,8,State Representative,16,,Write-In Totals,62
+Benton,8,State Representative,16,,Overvotes,0
+Benton,8,State Representative,16,,Undervotes,843
+Benton,8,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,963
+Benton,8,"County Commissioner, Position 1",,,Erik Gradine,362
+Benton,8,"County Commissioner, Position 1",,,Timothy L Dehne,66
+Benton,8,"County Commissioner, Position 1",,,Pat Malone,1845
+Benton,8,"County Commissioner, Position 1",,,Max Mania,221
+Benton,8,"County Commissioner, Position 1",,,Write-In Totals,11
+Benton,8,"County Commissioner, Position 1",,,Overvotes,1
+Benton,8,"County Commissioner, Position 1",,,Undervotes,293
+Benton,8,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,2434
+Benton,8,"Judge of the Supreme Court, Position 5",,,Write-In Totals,20
+Benton,8,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,8,"Judge of the Supreme Court, Position 5",,,Undervotes,1308
+Benton,8,"Judge of the Court of Appeals, Position 2",,,Bronson D James,2315
+Benton,8,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,22
+Benton,8,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,8,"Judge of the Court of Appeals, Position 2",,,Undervotes,1425
+Benton,8,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,2377
+Benton,8,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,16
+Benton,8,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,8,"Judge of the Court of Appeals, Position 4",,,Undervotes,1369
+Benton,8,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,2353
+Benton,8,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,17
+Benton,8,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,8,"Judge of the Court of Appeals, Position 7",,,Undervotes,1392
+Benton,8,Judge of the Oregon Tax Court,,,Robert Manicke,2346
+Benton,8,Judge of the Oregon Tax Court,,,Write-In Totals,17
+Benton,8,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,8,Judge of the Oregon Tax Court,,,Undervotes,1399
+Benton,8,Sheriff Benton County,,,Scott Jackson,2467
+Benton,8,Sheriff Benton County,,,Write-In Totals,25
+Benton,8,Sheriff Benton County,,,Overvotes,0
+Benton,8,Sheriff Benton County,,,Undervotes,1270
+Benton,8,Mayor City of Corvallis,,,Biff Traber,2093
+Benton,8,Mayor City of Corvallis,,,Dean Codo,131
+Benton,8,Mayor City of Corvallis,,,Riley Doraine,81
+Benton,8,Mayor City of Corvallis,,,Roen Hogg,1060
+Benton,8,Mayor City of Corvallis,,,Write-In Totals,19
+Benton,8,Mayor City of Corvallis,,,Overvotes,1
+Benton,8,Mayor City of Corvallis,,,Undervotes,377
+Benton,8,"City Council, Ward 8 City of Corvallis",,,Ed Junkins,2556
+Benton,8,"City Council, Ward 8 City of Corvallis",,,Write-In Totals,20
+Benton,8,"City Council, Ward 8 City of Corvallis",,,Overvotes,0
+Benton,8,"City Council, Ward 8 City of Corvallis",,,Undervotes,1186
+Benton,8,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,2340
+Benton,8,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,8,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,8,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1410
+Benton,8,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,2187
+Benton,8,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,17
+Benton,8,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,8,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1558
+Benton,8,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,2158
+Benton,8,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,18
+Benton,8,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,8,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1586
+Benton,8,State Measure 102,,,Yes,2374
+Benton,8,State Measure 102,,,No,1283
+Benton,8,State Measure 102,,,Overvotes,0
+Benton,8,State Measure 102,,,Undervotes,105
+Benton,8,State Measure 103,,,Yes,816
+Benton,8,State Measure 103,,,No,2865
+Benton,8,State Measure 103,,,Overvotes,2
+Benton,8,State Measure 103,,,Undervotes,79
+Benton,8,State Measure 104,,,Yes,810
+Benton,8,State Measure 104,,,No,2829
+Benton,8,State Measure 104,,,Overvotes,1
+Benton,8,State Measure 104,,,Undervotes,122
+Benton,8,State Measure 105,,,Yes,769
+Benton,8,State Measure 105,,,No,2943
+Benton,8,State Measure 105,,,Overvotes,1
+Benton,8,State Measure 105,,,Undervotes,49
+Benton,8,State Measure 106,,,Yes,769
+Benton,8,State Measure 106,,,No,2937
+Benton,8,State Measure 106,,,Overvotes,1
+Benton,8,State Measure 106,,,Undervotes,55
+Benton,9,Registered Voters - Total,,,,4001
+Benton,9,Ballots Cast - Total,,,,2944
+Benton,9,Ballots Cast - Blank,,,,0
+Benton,9,U.S. House,4,,Art Robinson,699
+Benton,9,U.S. House,4,,Richard R Jacobson,45
+Benton,9,U.S. House,4,,Mike Beilstein,67
+Benton,9,U.S. House,4,,Peter DeFazio,2073
+Benton,9,U.S. House,4,,Write-In Totals,2
+Benton,9,U.S. House,4,,Overvotes,0
+Benton,9,U.S. House,4,,Undervotes,58
+Benton,9,Governor,,,Aaron Auer,44
+Benton,9,Governor,,,Nick Chen,61
+Benton,9,Governor,,,Kate Brown,1761
+Benton,9,Governor,,,Knute Buehler,878
+Benton,9,Governor,,,Patrick Starnes,107
+Benton,9,Governor,,,Chris Henry,21
+Benton,9,Governor,,,Write-In Totals,2
+Benton,9,Governor,,,Overvotes,1
+Benton,9,Governor,,,Undervotes,59
+Benton,9,State Senator,8,,Sara A Gelser,2059
+Benton,9,State Senator,8,,Bryan Eggiman,65
+Benton,9,State Senator,8,,Erik S Parks,719
+Benton,9,State Senator,8,,Write-In Totals,5
+Benton,9,State Senator,8,,Overvotes,0
+Benton,9,State Senator,8,,Undervotes,86
+Benton,9,State Representative,16,,Dan Rayfield,2161
+Benton,9,State Representative,16,,Write-In Totals,74
+Benton,9,State Representative,16,,Overvotes,0
+Benton,9,State Representative,16,,Undervotes,699
+Benton,9,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,706
+Benton,9,"County Commissioner, Position 1",,,Erik Gradine,291
+Benton,9,"County Commissioner, Position 1",,,Timothy L Dehne,103
+Benton,9,"County Commissioner, Position 1",,,Pat Malone,1335
+Benton,9,"County Commissioner, Position 1",,,Max Mania,189
+Benton,9,"County Commissioner, Position 1",,,Write-In Totals,11
+Benton,9,"County Commissioner, Position 1",,,Overvotes,1
+Benton,9,"County Commissioner, Position 1",,,Undervotes,298
+Benton,9,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1949
+Benton,9,"Judge of the Supreme Court, Position 5",,,Write-In Totals,36
+Benton,9,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,9,"Judge of the Supreme Court, Position 5",,,Undervotes,949
+Benton,9,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1833
+Benton,9,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,43
+Benton,9,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,9,"Judge of the Court of Appeals, Position 2",,,Undervotes,1058
+Benton,9,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1892
+Benton,9,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,32
+Benton,9,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,9,"Judge of the Court of Appeals, Position 4",,,Undervotes,1010
+Benton,9,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1862
+Benton,9,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,32
+Benton,9,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,9,"Judge of the Court of Appeals, Position 7",,,Undervotes,1040
+Benton,9,Judge of the Oregon Tax Court,,,Robert Manicke,1863
+Benton,9,Judge of the Oregon Tax Court,,,Write-In Totals,31
+Benton,9,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,9,Judge of the Oregon Tax Court,,,Undervotes,1040
+Benton,9,Sheriff Benton County,,,Scott Jackson,1952
+Benton,9,Sheriff Benton County,,,Write-In Totals,47
+Benton,9,Sheriff Benton County,,,Overvotes,0
+Benton,9,Sheriff Benton County,,,Undervotes,935
+Benton,9,Mayor City of Corvallis,,,Biff Traber,1487
+Benton,9,Mayor City of Corvallis,,,Dean Codo,192
+Benton,9,Mayor City of Corvallis,,,Riley Doraine,165
+Benton,9,Mayor City of Corvallis,,,Roen Hogg,661
+Benton,9,Mayor City of Corvallis,,,Write-In Totals,19
+Benton,9,Mayor City of Corvallis,,,Overvotes,1
+Benton,9,Mayor City of Corvallis,,,Undervotes,409
+Benton,9,"City Council, Ward 9 City of Corvallis",,,Andrew Freborg,984
+Benton,9,"City Council, Ward 9 City of Corvallis",,,Andrew Struthers,1242
+Benton,9,"City Council, Ward 9 City of Corvallis",,,Write-In Totals,13
+Benton,9,"City Council, Ward 9 City of Corvallis",,,Overvotes,0
+Benton,9,"City Council, Ward 9 City of Corvallis",,,Undervotes,695
+Benton,9,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1819
+Benton,9,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,24
+Benton,9,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,9,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1091
+Benton,9,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1727
+Benton,9,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,29
+Benton,9,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,9,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1178
+Benton,9,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1712
+Benton,9,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,35
+Benton,9,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,9,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1187
+Benton,9,State Measure 102,,,Yes,1874
+Benton,9,State Measure 102,,,No,944
+Benton,9,State Measure 102,,,Overvotes,0
+Benton,9,State Measure 102,,,Undervotes,116
+Benton,9,State Measure 103,,,Yes,913
+Benton,9,State Measure 103,,,No,1963
+Benton,9,State Measure 103,,,Overvotes,1
+Benton,9,State Measure 103,,,Undervotes,57
+Benton,9,State Measure 104,,,Yes,755
+Benton,9,State Measure 104,,,No,2068
+Benton,9,State Measure 104,,,Overvotes,2
+Benton,9,State Measure 104,,,Undervotes,109
+Benton,9,State Measure 105,,,Yes,701
+Benton,9,State Measure 105,,,No,2166
+Benton,9,State Measure 105,,,Overvotes,2
+Benton,9,State Measure 105,,,Undervotes,65
+Benton,9,State Measure 106,,,Yes,742
+Benton,9,State Measure 106,,,No,2148
+Benton,9,State Measure 106,,,Overvotes,0
+Benton,9,State Measure 106,,,Undervotes,44
+Benton,10,Registered Voters - Total,,,,3305
+Benton,10,Ballots Cast - Total,,,,2355
+Benton,10,Ballots Cast - Blank,,,,0
+Benton,10,U.S. House,4,,Art Robinson,754
+Benton,10,U.S. House,4,,Richard R Jacobson,42
+Benton,10,U.S. House,4,,Mike Beilstein,59
+Benton,10,U.S. House,4,,Peter DeFazio,1445
+Benton,10,U.S. House,4,,Write-In Totals,8
+Benton,10,U.S. House,4,,Overvotes,0
+Benton,10,U.S. House,4,,Undervotes,47
+Benton,10,Governor,,,Aaron Auer,35
+Benton,10,Governor,,,Nick Chen,54
+Benton,10,Governor,,,Kate Brown,1172
+Benton,10,Governor,,,Knute Buehler,918
+Benton,10,Governor,,,Patrick Starnes,101
+Benton,10,Governor,,,Chris Henry,24
+Benton,10,Governor,,,Write-In Totals,4
+Benton,10,Governor,,,Overvotes,0
+Benton,10,Governor,,,Undervotes,45
+Benton,10,State Senator,8,,Sara A Gelser,1457
+Benton,10,State Senator,8,,Bryan Eggiman,61
+Benton,10,State Senator,8,,Erik S Parks,761
+Benton,10,State Senator,8,,Write-In Totals,3
+Benton,10,State Senator,8,,Overvotes,1
+Benton,10,State Senator,8,,Undervotes,70
+Benton,10,State Representative,16,,Dan Rayfield,1623
+Benton,10,State Representative,16,,Write-In Totals,71
+Benton,10,State Representative,16,,Overvotes,0
+Benton,10,State Representative,16,,Undervotes,659
+Benton,10,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,421
+Benton,10,"County Commissioner, Position 1",,,Erik Gradine,281
+Benton,10,"County Commissioner, Position 1",,,Timothy L Dehne,84
+Benton,10,"County Commissioner, Position 1",,,Pat Malone,1019
+Benton,10,"County Commissioner, Position 1",,,Max Mania,248
+Benton,10,"County Commissioner, Position 1",,,Write-In Totals,19
+Benton,10,"County Commissioner, Position 1",,,Overvotes,3
+Benton,10,"County Commissioner, Position 1",,,Undervotes,278
+Benton,10,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1464
+Benton,10,"Judge of the Supreme Court, Position 5",,,Write-In Totals,26
+Benton,10,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,10,"Judge of the Supreme Court, Position 5",,,Undervotes,863
+Benton,10,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1386
+Benton,10,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,29
+Benton,10,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,10,"Judge of the Court of Appeals, Position 2",,,Undervotes,938
+Benton,10,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1443
+Benton,10,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,26
+Benton,10,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,10,"Judge of the Court of Appeals, Position 4",,,Undervotes,884
+Benton,10,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1430
+Benton,10,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,26
+Benton,10,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,10,"Judge of the Court of Appeals, Position 7",,,Undervotes,897
+Benton,10,Judge of the Oregon Tax Court,,,Robert Manicke,1419
+Benton,10,Judge of the Oregon Tax Court,,,Write-In Totals,22
+Benton,10,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,10,Judge of the Oregon Tax Court,,,Undervotes,912
+Benton,10,Sheriff Benton County,,,Scott Jackson,1540
+Benton,10,Sheriff Benton County,,,Write-In Totals,36
+Benton,10,Sheriff Benton County,,,Overvotes,1
+Benton,10,Sheriff Benton County,,,Undervotes,776
+Benton,10,Mayor City of Philomath,,,"Jerry J Jackson, Sr",781
+Benton,10,Mayor City of Philomath,,,Eric Niemann,1283
+Benton,10,Mayor City of Philomath,,,Write-In Totals,25
+Benton,10,Mayor City of Philomath,,,Overvotes,0
+Benton,10,Mayor City of Philomath,,,Undervotes,264
+Benton,10,City Council City of Philomath,,,Chas Jones,1364
+Benton,10,City Council City of Philomath,,,David M Low,1078
+Benton,10,City Council City of Philomath,,,Terry Weiss,1257
+Benton,10,City Council City of Philomath,,,Candy Koetz,729
+Benton,10,City Council City of Philomath,,,Doug Edmonds,1128
+Benton,10,City Council City of Philomath,,,Matthew Thomas,888
+Benton,10,City Council City of Philomath,,,Noelle Cummings,850
+Benton,10,City Council City of Philomath,,,Jason Bushnell,811
+Benton,10,City Council City of Philomath,,,Marion Dark,1276
+Benton,10,City Council City of Philomath,,,Write-In Totals,160
+Benton,10,City Council City of Philomath,,,Overvotes,42
+Benton,10,City Council City of Philomath,,,Undervotes,4535
+Benton,10,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1466
+Benton,10,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,10,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,10,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,876
+Benton,10,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1380
+Benton,10,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,10,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,10,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,962
+Benton,10,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1367
+Benton,10,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,14
+Benton,10,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,10,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,972
+Benton,10,State Measure 102,,,Yes,1300
+Benton,10,State Measure 102,,,No,974
+Benton,10,State Measure 102,,,Overvotes,1
+Benton,10,State Measure 102,,,Undervotes,78
+Benton,10,State Measure 103,,,Yes,810
+Benton,10,State Measure 103,,,No,1502
+Benton,10,State Measure 103,,,Overvotes,1
+Benton,10,State Measure 103,,,Undervotes,40
+Benton,10,State Measure 104,,,Yes,717
+Benton,10,State Measure 104,,,No,1553
+Benton,10,State Measure 104,,,Overvotes,0
+Benton,10,State Measure 104,,,Undervotes,83
+Benton,10,State Measure 105,,,Yes,707
+Benton,10,State Measure 105,,,No,1611
+Benton,10,State Measure 105,,,Overvotes,0
+Benton,10,State Measure 105,,,Undervotes,35
+Benton,10,State Measure 106,,,Yes,769
+Benton,10,State Measure 106,,,No,1548
+Benton,10,State Measure 106,,,Overvotes,1
+Benton,10,State Measure 106,,,Undervotes,35
+Benton,12,Registered Voters - Total,,,,553
+Benton,12,Ballots Cast - Total,,,,394
+Benton,12,Ballots Cast - Blank,,,,0
+Benton,12,U.S. House,5,,Mark Callahan,164
+Benton,12,U.S. House,5,,Dan Souza,6
+Benton,12,U.S. House,5,,Marvin Sandnes,8
+Benton,12,U.S. House,5,,Kurt Schrader,200
+Benton,12,U.S. House,5,,Write-In Totals,0
+Benton,12,U.S. House,5,,Overvotes,0
+Benton,12,U.S. House,5,,Undervotes,16
+Benton,12,Governor,,,Aaron Auer,8
+Benton,12,Governor,,,Nick Chen,7
+Benton,12,Governor,,,Kate Brown,177
+Benton,12,Governor,,,Knute Buehler,172
+Benton,12,Governor,,,Patrick Starnes,15
+Benton,12,Governor,,,Chris Henry,7
+Benton,12,Governor,,,Write-In Totals,0
+Benton,12,Governor,,,Overvotes,0
+Benton,12,Governor,,,Undervotes,7
+Benton,12,State Representative,23,,Danny Jaffer,202
+Benton,12,State Representative,23,,Mark Karnowski,7
+Benton,12,State Representative,23,,Mike Nearman,164
+Benton,12,State Representative,23,,Write-In Totals,0
+Benton,12,State Representative,23,,Overvotes,0
+Benton,12,State Representative,23,,Undervotes,20
+Benton,12,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,86
+Benton,12,"County Commissioner, Position 1",,,Erik Gradine,64
+Benton,12,"County Commissioner, Position 1",,,Timothy L Dehne,17
+Benton,12,"County Commissioner, Position 1",,,Pat Malone,125
+Benton,12,"County Commissioner, Position 1",,,Max Mania,46
+Benton,12,"County Commissioner, Position 1",,,Write-In Totals,1
+Benton,12,"County Commissioner, Position 1",,,Overvotes,0
+Benton,12,"County Commissioner, Position 1",,,Undervotes,54
+Benton,12,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,242
+Benton,12,"Judge of the Supreme Court, Position 5",,,Write-In Totals,5
+Benton,12,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,12,"Judge of the Supreme Court, Position 5",,,Undervotes,146
+Benton,12,"Judge of the Court of Appeals, Position 2",,,Bronson D James,222
+Benton,12,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,7
+Benton,12,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,12,"Judge of the Court of Appeals, Position 2",,,Undervotes,164
+Benton,12,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,234
+Benton,12,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,7
+Benton,12,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,12,"Judge of the Court of Appeals, Position 4",,,Undervotes,152
+Benton,12,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,228
+Benton,12,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,6
+Benton,12,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,12,"Judge of the Court of Appeals, Position 7",,,Undervotes,159
+Benton,12,Judge of the Oregon Tax Court,,,Robert Manicke,225
+Benton,12,Judge of the Oregon Tax Court,,,Write-In Totals,6
+Benton,12,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,12,Judge of the Oregon Tax Court,,,Undervotes,162
+Benton,12,Sheriff Benton County,,,Scott Jackson,253
+Benton,12,Sheriff Benton County,,,Write-In Totals,4
+Benton,12,Sheriff Benton County,,,Overvotes,0
+Benton,12,Sheriff Benton County,,,Undervotes,136
+Benton,12,Mayor City of Adair Village,,,Bill Currier,255
+Benton,12,Mayor City of Adair Village,,,Write-In Totals,23
+Benton,12,Mayor City of Adair Village,,,Overvotes,0
+Benton,12,Mayor City of Adair Village,,,Undervotes,115
+Benton,12,City Council City of Adair Village,,,Bret P Ray,195
+Benton,12,City Council City of Adair Village,,,Charline King,202
+Benton,12,City Council City of Adair Village,,,Write-In Totals,15
+Benton,12,City Council City of Adair Village,,,Overvotes,0
+Benton,12,City Council City of Adair Village,,,Undervotes,374
+Benton,12,City Council City of Adair Village,,,Alan W Rowe,250
+Benton,12,City Council City of Adair Village,,,Write-In Totals,5
+Benton,12,City Council City of Adair Village,,,Overvotes,0
+Benton,12,City Council City of Adair Village,,,Undervotes,138
+Benton,12,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,232
+Benton,12,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,12,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,12,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,158
+Benton,12,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,227
+Benton,12,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,12,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,12,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,163
+Benton,12,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,223
+Benton,12,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,4
+Benton,12,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,12,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,166
+Benton,12,State Measure 102,,,Yes,226
+Benton,12,State Measure 102,,,No,146
+Benton,12,State Measure 102,,,Overvotes,0
+Benton,12,State Measure 102,,,Undervotes,21
+Benton,12,State Measure 103,,,Yes,168
+Benton,12,State Measure 103,,,No,212
+Benton,12,State Measure 103,,,Overvotes,0
+Benton,12,State Measure 103,,,Undervotes,13
+Benton,12,State Measure 104,,,Yes,166
+Benton,12,State Measure 104,,,No,205
+Benton,12,State Measure 104,,,Overvotes,0
+Benton,12,State Measure 104,,,Undervotes,22
+Benton,12,State Measure 105,,,Yes,144
+Benton,12,State Measure 105,,,No,238
+Benton,12,State Measure 105,,,Overvotes,0
+Benton,12,State Measure 105,,,Undervotes,11
+Benton,12,State Measure 106,,,Yes,169
+Benton,12,State Measure 106,,,No,219
+Benton,12,State Measure 106,,,Overvotes,0
+Benton,12,State Measure 106,,,Undervotes,5
+Benton,13,Registered Voters - Total,,,,375
+Benton,13,Ballots Cast - Total,,,,227
+Benton,13,Ballots Cast - Blank,,,,0
+Benton,13,U.S. House,4,,Art Robinson,109
+Benton,13,U.S. House,4,,Richard R Jacobson,5
+Benton,13,U.S. House,4,,Mike Beilstein,2
+Benton,13,U.S. House,4,,Peter DeFazio,108
+Benton,13,U.S. House,4,,Write-In Totals,0
+Benton,13,U.S. House,4,,Overvotes,0
+Benton,13,U.S. House,4,,Undervotes,3
+Benton,13,Governor,,,Aaron Auer,0
+Benton,13,Governor,,,Nick Chen,3
+Benton,13,Governor,,,Kate Brown,67
+Benton,13,Governor,,,Knute Buehler,138
+Benton,13,Governor,,,Patrick Starnes,14
+Benton,13,Governor,,,Chris Henry,2
+Benton,13,Governor,,,Write-In Totals,0
+Benton,13,Governor,,,Overvotes,0
+Benton,13,Governor,,,Undervotes,3
+Benton,13,State Representative,23,,Danny Jaffer,100
+Benton,13,State Representative,23,,Mark Karnowski,3
+Benton,13,State Representative,23,,Mike Nearman,113
+Benton,13,State Representative,23,,Write-In Totals,0
+Benton,13,State Representative,23,,Overvotes,0
+Benton,13,State Representative,23,,Undervotes,11
+Benton,13,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,33
+Benton,13,"County Commissioner, Position 1",,,Erik Gradine,42
+Benton,13,"County Commissioner, Position 1",,,Timothy L Dehne,13
+Benton,13,"County Commissioner, Position 1",,,Pat Malone,80
+Benton,13,"County Commissioner, Position 1",,,Max Mania,27
+Benton,13,"County Commissioner, Position 1",,,Write-In Totals,2
+Benton,13,"County Commissioner, Position 1",,,Overvotes,1
+Benton,13,"County Commissioner, Position 1",,,Undervotes,29
+Benton,13,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,139
+Benton,13,"Judge of the Supreme Court, Position 5",,,Write-In Totals,2
+Benton,13,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,13,"Judge of the Supreme Court, Position 5",,,Undervotes,86
+Benton,13,"Judge of the Court of Appeals, Position 2",,,Bronson D James,134
+Benton,13,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,2
+Benton,13,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,13,"Judge of the Court of Appeals, Position 2",,,Undervotes,91
+Benton,13,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,140
+Benton,13,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,2
+Benton,13,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,13,"Judge of the Court of Appeals, Position 4",,,Undervotes,85
+Benton,13,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,136
+Benton,13,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,1
+Benton,13,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,13,"Judge of the Court of Appeals, Position 7",,,Undervotes,90
+Benton,13,Judge of the Oregon Tax Court,,,Robert Manicke,135
+Benton,13,Judge of the Oregon Tax Court,,,Write-In Totals,1
+Benton,13,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,13,Judge of the Oregon Tax Court,,,Undervotes,91
+Benton,13,Sheriff Benton County,,,Scott Jackson,147
+Benton,13,Sheriff Benton County,,,Write-In Totals,1
+Benton,13,Sheriff Benton County,,,Overvotes,0
+Benton,13,Sheriff Benton County,,,Undervotes,79
+Benton,13,Mayor City of Monroe,,,Paul Canter,127
+Benton,13,Mayor City of Monroe,,,Floyd Billings,89
+Benton,13,Mayor City of Monroe,,,Write-In Totals,1
+Benton,13,Mayor City of Monroe,,,Overvotes,0
+Benton,13,Mayor City of Monroe,,,Undervotes,10
+Benton,13,City Council City of Monroe,,,Lonnie Koroush,113
+Benton,13,City Council City of Monroe,,,Jeannine E Cuthbertson,134
+Benton,13,City Council City of Monroe,,,Harry M Myers,106
+Benton,13,City Council City of Monroe,,,Chad M Howard,127
+Benton,13,City Council City of Monroe,,,Write-In Totals,15
+Benton,13,City Council City of Monroe,,,Overvotes,3
+Benton,13,City Council City of Monroe,,,Undervotes,183
+Benton,13,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,134
+Benton,13,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,2
+Benton,13,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,13,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,91
+Benton,13,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,130
+Benton,13,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,13,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,13,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,94
+Benton,13,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,136
+Benton,13,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,2
+Benton,13,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,13,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,89
+Benton,13,State Measure 102,,,Yes,97
+Benton,13,State Measure 102,,,No,121
+Benton,13,State Measure 102,,,Overvotes,0
+Benton,13,State Measure 102,,,Undervotes,9
+Benton,13,State Measure 103,,,Yes,116
+Benton,13,State Measure 103,,,No,105
+Benton,13,State Measure 103,,,Overvotes,0
+Benton,13,State Measure 103,,,Undervotes,6
+Benton,13,State Measure 104,,,Yes,99
+Benton,13,State Measure 104,,,No,119
+Benton,13,State Measure 104,,,Overvotes,0
+Benton,13,State Measure 104,,,Undervotes,9
+Benton,13,State Measure 105,,,Yes,113
+Benton,13,State Measure 105,,,No,114
+Benton,13,State Measure 105,,,Overvotes,0
+Benton,13,State Measure 105,,,Undervotes,0
+Benton,13,State Measure 106,,,Yes,117
+Benton,13,State Measure 106,,,No,105
+Benton,13,State Measure 106,,,Overvotes,0
+Benton,13,State Measure 106,,,Undervotes,5
+Benton,14,Registered Voters - Total,,,,702
+Benton,14,Ballots Cast - Total,,,,503
+Benton,14,Ballots Cast - Blank,,,,2
+Benton,14,U.S. House,4,,Art Robinson,257
+Benton,14,U.S. House,4,,Richard R Jacobson,5
+Benton,14,U.S. House,4,,Mike Beilstein,15
+Benton,14,U.S. House,4,,Peter DeFazio,212
+Benton,14,U.S. House,4,,Write-In Totals,1
+Benton,14,U.S. House,4,,Overvotes,0
+Benton,14,U.S. House,4,,Undervotes,13
+Benton,14,Governor,,,Aaron Auer,12
+Benton,14,Governor,,,Nick Chen,5
+Benton,14,Governor,,,Kate Brown,152
+Benton,14,Governor,,,Knute Buehler,276
+Benton,14,Governor,,,Patrick Starnes,37
+Benton,14,Governor,,,Chris Henry,8
+Benton,14,Governor,,,Write-In Totals,2
+Benton,14,Governor,,,Overvotes,0
+Benton,14,Governor,,,Undervotes,11
+Benton,14,State Representative,23,,Danny Jaffer,209
+Benton,14,State Representative,23,,Mark Karnowski,11
+Benton,14,State Representative,23,,Mike Nearman,265
+Benton,14,State Representative,23,,Write-In Totals,0
+Benton,14,State Representative,23,,Overvotes,0
+Benton,14,State Representative,23,,Undervotes,18
+Benton,14,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,58
+Benton,14,"County Commissioner, Position 1",,,Erik Gradine,100
+Benton,14,"County Commissioner, Position 1",,,Timothy L Dehne,29
+Benton,14,"County Commissioner, Position 1",,,Pat Malone,156
+Benton,14,"County Commissioner, Position 1",,,Max Mania,53
+Benton,14,"County Commissioner, Position 1",,,Write-In Totals,9
+Benton,14,"County Commissioner, Position 1",,,Overvotes,0
+Benton,14,"County Commissioner, Position 1",,,Undervotes,98
+Benton,14,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,253
+Benton,14,"Judge of the Supreme Court, Position 5",,,Write-In Totals,5
+Benton,14,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,14,"Judge of the Supreme Court, Position 5",,,Undervotes,245
+Benton,14,"Judge of the Court of Appeals, Position 2",,,Bronson D James,236
+Benton,14,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,7
+Benton,14,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,14,"Judge of the Court of Appeals, Position 2",,,Undervotes,260
+Benton,14,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,247
+Benton,14,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,5
+Benton,14,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,14,"Judge of the Court of Appeals, Position 4",,,Undervotes,251
+Benton,14,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,243
+Benton,14,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,5
+Benton,14,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,14,"Judge of the Court of Appeals, Position 7",,,Undervotes,255
+Benton,14,Judge of the Oregon Tax Court,,,Robert Manicke,238
+Benton,14,Judge of the Oregon Tax Court,,,Write-In Totals,7
+Benton,14,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,14,Judge of the Oregon Tax Court,,,Undervotes,258
+Benton,14,Sheriff Benton County,,,Scott Jackson,279
+Benton,14,Sheriff Benton County,,,Write-In Totals,3
+Benton,14,Sheriff Benton County,,,Overvotes,0
+Benton,14,Sheriff Benton County,,,Undervotes,221
+Benton,14,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,250
+Benton,14,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,14,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,14,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,250
+Benton,14,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,269
+Benton,14,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,4
+Benton,14,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,14,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,230
+Benton,14,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,241
+Benton,14,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,14,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,14,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,259
+Benton,14,State Measure 102,,,Yes,219
+Benton,14,State Measure 102,,,No,266
+Benton,14,State Measure 102,,,Overvotes,0
+Benton,14,State Measure 102,,,Undervotes,18
+Benton,14,State Measure 103,,,Yes,233
+Benton,14,State Measure 103,,,No,253
+Benton,14,State Measure 103,,,Overvotes,1
+Benton,14,State Measure 103,,,Undervotes,16
+Benton,14,State Measure 104,,,Yes,205
+Benton,14,State Measure 104,,,No,273
+Benton,14,State Measure 104,,,Overvotes,0
+Benton,14,State Measure 104,,,Undervotes,25
+Benton,14,State Measure 105,,,Yes,236
+Benton,14,State Measure 105,,,No,255
+Benton,14,State Measure 105,,,Overvotes,0
+Benton,14,State Measure 105,,,Undervotes,12
+Benton,14,State Measure 106,,,Yes,209
+Benton,14,State Measure 106,,,No,280
+Benton,14,State Measure 106,,,Overvotes,2
+Benton,14,State Measure 106,,,Undervotes,12
+Benton,15,Registered Voters - Total,,,,2813
+Benton,15,Ballots Cast - Total,,,,2177
+Benton,15,Ballots Cast - Blank,,,,0
+Benton,15,U.S. House,4,,Art Robinson,901
+Benton,15,U.S. House,4,,Richard R Jacobson,33
+Benton,15,U.S. House,4,,Mike Beilstein,28
+Benton,15,U.S. House,4,,Peter DeFazio,1178
+Benton,15,U.S. House,4,,Write-In Totals,1
+Benton,15,U.S. House,4,,Overvotes,0
+Benton,15,U.S. House,4,,Undervotes,36
+Benton,15,Governor,,,Aaron Auer,27
+Benton,15,Governor,,,Nick Chen,39
+Benton,15,Governor,,,Kate Brown,973
+Benton,15,Governor,,,Knute Buehler,1039
+Benton,15,Governor,,,Patrick Starnes,58
+Benton,15,Governor,,,Chris Henry,10
+Benton,15,Governor,,,Write-In Totals,1
+Benton,15,Governor,,,Overvotes,0
+Benton,15,Governor,,,Undervotes,27
+Benton,15,State Representative,23,,Danny Jaffer,1121
+Benton,15,State Representative,23,,Mark Karnowski,50
+Benton,15,State Representative,23,,Mike Nearman,931
+Benton,15,State Representative,23,,Write-In Totals,1
+Benton,15,State Representative,23,,Overvotes,1
+Benton,15,State Representative,23,,Undervotes,70
+Benton,15,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,268
+Benton,15,"County Commissioner, Position 1",,,Erik Gradine,320
+Benton,15,"County Commissioner, Position 1",,,Timothy L Dehne,66
+Benton,15,"County Commissioner, Position 1",,,Pat Malone,1060
+Benton,15,"County Commissioner, Position 1",,,Max Mania,160
+Benton,15,"County Commissioner, Position 1",,,Write-In Totals,15
+Benton,15,"County Commissioner, Position 1",,,Overvotes,2
+Benton,15,"County Commissioner, Position 1",,,Undervotes,283
+Benton,15,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1137
+Benton,15,"Judge of the Supreme Court, Position 5",,,Write-In Totals,21
+Benton,15,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,15,"Judge of the Supreme Court, Position 5",,,Undervotes,1016
+Benton,15,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1070
+Benton,15,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,15
+Benton,15,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,15,"Judge of the Court of Appeals, Position 2",,,Undervotes,1089
+Benton,15,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1100
+Benton,15,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,16
+Benton,15,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,15,"Judge of the Court of Appeals, Position 4",,,Undervotes,1058
+Benton,15,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1073
+Benton,15,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,16
+Benton,15,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,15,"Judge of the Court of Appeals, Position 7",,,Undervotes,1085
+Benton,15,Judge of the Oregon Tax Court,,,Robert Manicke,1074
+Benton,15,Judge of the Oregon Tax Court,,,Write-In Totals,15
+Benton,15,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,15,Judge of the Oregon Tax Court,,,Undervotes,1085
+Benton,15,Sheriff Benton County,,,Scott Jackson,1231
+Benton,15,Sheriff Benton County,,,Write-In Totals,25
+Benton,15,Sheriff Benton County,,,Overvotes,0
+Benton,15,Sheriff Benton County,,,Undervotes,918
+Benton,15,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1154
+Benton,15,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,15,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,15,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1008
+Benton,15,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1079
+Benton,15,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,15,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,15,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1083
+Benton,15,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1070
+Benton,15,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,15,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,15,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1092
+Benton,15,State Measure 102,,,Yes,1110
+Benton,15,State Measure 102,,,No,1018
+Benton,15,State Measure 102,,,Overvotes,0
+Benton,15,State Measure 102,,,Undervotes,46
+Benton,15,State Measure 103,,,Yes,862
+Benton,15,State Measure 103,,,No,1275
+Benton,15,State Measure 103,,,Overvotes,1
+Benton,15,State Measure 103,,,Undervotes,36
+Benton,15,State Measure 104,,,Yes,779
+Benton,15,State Measure 104,,,No,1326
+Benton,15,State Measure 104,,,Overvotes,1
+Benton,15,State Measure 104,,,Undervotes,68
+Benton,15,State Measure 105,,,Yes,848
+Benton,15,State Measure 105,,,No,1288
+Benton,15,State Measure 105,,,Overvotes,1
+Benton,15,State Measure 105,,,Undervotes,37
+Benton,15,State Measure 106,,,Yes,803
+Benton,15,State Measure 106,,,No,1330
+Benton,15,State Measure 106,,,Overvotes,1
+Benton,15,State Measure 106,,,Undervotes,40
+Benton,16,Registered Voters - Total,,,,3209
+Benton,16,Ballots Cast - Total,,,,2661
+Benton,16,Ballots Cast - Blank,,,,0
+Benton,16,U.S. House,4,,Art Robinson,771
+Benton,16,U.S. House,4,,Richard R Jacobson,27
+Benton,16,U.S. House,4,,Mike Beilstein,50
+Benton,16,U.S. House,4,,Peter DeFazio,1778
+Benton,16,U.S. House,4,,Write-In Totals,2
+Benton,16,U.S. House,4,,Overvotes,1
+Benton,16,U.S. House,4,,Undervotes,32
+Benton,16,Governor,,,Aaron Auer,12
+Benton,16,Governor,,,Nick Chen,24
+Benton,16,Governor,,,Kate Brown,1578
+Benton,16,Governor,,,Knute Buehler,933
+Benton,16,Governor,,,Patrick Starnes,53
+Benton,16,Governor,,,Chris Henry,13
+Benton,16,Governor,,,Write-In Totals,2
+Benton,16,Governor,,,Overvotes,1
+Benton,16,Governor,,,Undervotes,36
+Benton,16,State Senator,8,,Sara A Gelser,1775
+Benton,16,State Senator,8,,Bryan Eggiman,48
+Benton,16,State Senator,8,,Erik S Parks,764
+Benton,16,State Senator,8,,Write-In Totals,4
+Benton,16,State Senator,8,,Overvotes,0
+Benton,16,State Senator,8,,Undervotes,61
+Benton,16,State Representative,16,,Dan Rayfield,1840
+Benton,16,State Representative,16,,Write-In Totals,66
+Benton,16,State Representative,16,,Overvotes,0
+Benton,16,State Representative,16,,Undervotes,746
+Benton,16,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,618
+Benton,16,"County Commissioner, Position 1",,,Erik Gradine,279
+Benton,16,"County Commissioner, Position 1",,,Timothy L Dehne,77
+Benton,16,"County Commissioner, Position 1",,,Pat Malone,1228
+Benton,16,"County Commissioner, Position 1",,,Max Mania,156
+Benton,16,"County Commissioner, Position 1",,,Write-In Totals,15
+Benton,16,"County Commissioner, Position 1",,,Overvotes,0
+Benton,16,"County Commissioner, Position 1",,,Undervotes,279
+Benton,16,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1609
+Benton,16,"Judge of the Supreme Court, Position 5",,,Write-In Totals,14
+Benton,16,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,16,"Judge of the Supreme Court, Position 5",,,Undervotes,1029
+Benton,16,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1511
+Benton,16,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,14
+Benton,16,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,16,"Judge of the Court of Appeals, Position 2",,,Undervotes,1127
+Benton,16,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1557
+Benton,16,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,17
+Benton,16,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,16,"Judge of the Court of Appeals, Position 4",,,Undervotes,1078
+Benton,16,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1522
+Benton,16,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,15
+Benton,16,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,16,"Judge of the Court of Appeals, Position 7",,,Undervotes,1115
+Benton,16,Judge of the Oregon Tax Court,,,Robert Manicke,1516
+Benton,16,Judge of the Oregon Tax Court,,,Write-In Totals,15
+Benton,16,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,16,Judge of the Oregon Tax Court,,,Undervotes,1121
+Benton,16,Sheriff Benton County,,,Scott Jackson,1644
+Benton,16,Sheriff Benton County,,,Write-In Totals,24
+Benton,16,Sheriff Benton County,,,Overvotes,0
+Benton,16,Sheriff Benton County,,,Undervotes,984
+Benton,16,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1617
+Benton,16,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,11
+Benton,16,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,16,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1024
+Benton,16,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1540
+Benton,16,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,12
+Benton,16,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,16,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1100
+Benton,16,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1426
+Benton,16,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,19
+Benton,16,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,16,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1207
+Benton,16,State Measure 102,,,Yes,1537
+Benton,16,State Measure 102,,,No,1043
+Benton,16,State Measure 102,,,Overvotes,2
+Benton,16,State Measure 102,,,Undervotes,70
+Benton,16,State Measure 103,,,Yes,758
+Benton,16,State Measure 103,,,No,1847
+Benton,16,State Measure 103,,,Overvotes,2
+Benton,16,State Measure 103,,,Undervotes,45
+Benton,16,State Measure 104,,,Yes,732
+Benton,16,State Measure 104,,,No,1840
+Benton,16,State Measure 104,,,Overvotes,0
+Benton,16,State Measure 104,,,Undervotes,80
+Benton,16,State Measure 105,,,Yes,731
+Benton,16,State Measure 105,,,No,1879
+Benton,16,State Measure 105,,,Overvotes,0
+Benton,16,State Measure 105,,,Undervotes,42
+Benton,16,State Measure 106,,,Yes,701
+Benton,16,State Measure 106,,,No,1904
+Benton,16,State Measure 106,,,Overvotes,0
+Benton,16,State Measure 106,,,Undervotes,47
+Benton,16,20-120 Ridgewood Road District,,,Yes,68
+Benton,16,20-120 Ridgewood Road District,,,No,26
+Benton,16,20-120 Ridgewood Road District,,,Overvotes,0
+Benton,16,20-120 Ridgewood Road District,,,Undervotes,3
+Benton,17,Registered Voters - Total,,,,1543
+Benton,17,Ballots Cast - Total,,,,1337
+Benton,17,Ballots Cast - Blank,,,,0
+Benton,17,U.S. House,4,,Art Robinson,376
+Benton,17,U.S. House,4,,Richard R Jacobson,23
+Benton,17,U.S. House,4,,Mike Beilstein,17
+Benton,17,U.S. House,4,,Peter DeFazio,908
+Benton,17,U.S. House,4,,Write-In Totals,0
+Benton,17,U.S. House,4,,Overvotes,0
+Benton,17,U.S. House,4,,Undervotes,13
+Benton,17,Governor,,,Aaron Auer,13
+Benton,17,Governor,,,Nick Chen,15
+Benton,17,Governor,,,Kate Brown,783
+Benton,17,Governor,,,Knute Buehler,455
+Benton,17,Governor,,,Patrick Starnes,34
+Benton,17,Governor,,,Chris Henry,6
+Benton,17,Governor,,,Write-In Totals,0
+Benton,17,Governor,,,Overvotes,1
+Benton,17,Governor,,,Undervotes,22
+Benton,17,State Representative,23,,Danny Jaffer,855
+Benton,17,State Representative,23,,Mark Karnowski,22
+Benton,17,State Representative,23,,Mike Nearman,417
+Benton,17,State Representative,23,,Write-In Totals,0
+Benton,17,State Representative,23,,Overvotes,0
+Benton,17,State Representative,23,,Undervotes,35
+Benton,17,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,288
+Benton,17,"County Commissioner, Position 1",,,Erik Gradine,153
+Benton,17,"County Commissioner, Position 1",,,Timothy L Dehne,42
+Benton,17,"County Commissioner, Position 1",,,Pat Malone,635
+Benton,17,"County Commissioner, Position 1",,,Max Mania,73
+Benton,17,"County Commissioner, Position 1",,,Write-In Totals,3
+Benton,17,"County Commissioner, Position 1",,,Overvotes,0
+Benton,17,"County Commissioner, Position 1",,,Undervotes,135
+Benton,17,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,821
+Benton,17,"Judge of the Supreme Court, Position 5",,,Write-In Totals,13
+Benton,17,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,17,"Judge of the Supreme Court, Position 5",,,Undervotes,495
+Benton,17,"Judge of the Court of Appeals, Position 2",,,Bronson D James,758
+Benton,17,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,12
+Benton,17,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,17,"Judge of the Court of Appeals, Position 2",,,Undervotes,559
+Benton,17,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,795
+Benton,17,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,11
+Benton,17,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,17,"Judge of the Court of Appeals, Position 4",,,Undervotes,523
+Benton,17,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,780
+Benton,17,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,11
+Benton,17,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,17,"Judge of the Court of Appeals, Position 7",,,Undervotes,538
+Benton,17,Judge of the Oregon Tax Court,,,Robert Manicke,784
+Benton,17,Judge of the Oregon Tax Court,,,Write-In Totals,10
+Benton,17,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,17,Judge of the Oregon Tax Court,,,Undervotes,535
+Benton,17,Sheriff Benton County,,,Scott Jackson,820
+Benton,17,Sheriff Benton County,,,Write-In Totals,28
+Benton,17,Sheriff Benton County,,,Overvotes,0
+Benton,17,Sheriff Benton County,,,Undervotes,481
+Benton,17,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,816
+Benton,17,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,7
+Benton,17,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,17,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,506
+Benton,17,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,769
+Benton,17,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,5
+Benton,17,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,17,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,555
+Benton,17,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,763
+Benton,17,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,6
+Benton,17,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,17,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,560
+Benton,17,State Measure 102,,,Yes,790
+Benton,17,State Measure 102,,,No,525
+Benton,17,State Measure 102,,,Overvotes,0
+Benton,17,State Measure 102,,,Undervotes,14
+Benton,17,State Measure 103,,,Yes,410
+Benton,17,State Measure 103,,,No,900
+Benton,17,State Measure 103,,,Overvotes,0
+Benton,17,State Measure 103,,,Undervotes,19
+Benton,17,State Measure 104,,,Yes,414
+Benton,17,State Measure 104,,,No,882
+Benton,17,State Measure 104,,,Overvotes,0
+Benton,17,State Measure 104,,,Undervotes,33
+Benton,17,State Measure 105,,,Yes,363
+Benton,17,State Measure 105,,,No,939
+Benton,17,State Measure 105,,,Overvotes,0
+Benton,17,State Measure 105,,,Undervotes,27
+Benton,17,State Measure 106,,,Yes,365
+Benton,17,State Measure 106,,,No,939
+Benton,17,State Measure 106,,,Overvotes,0
+Benton,17,State Measure 106,,,Undervotes,25
+Benton,18,Registered Voters - Total,,,,1650
+Benton,18,Ballots Cast - Total,,,,1321
+Benton,18,Ballots Cast - Blank,,,,0
+Benton,18,U.S. House,5,,Mark Callahan,732
+Benton,18,U.S. House,5,,Dan Souza,16
+Benton,18,U.S. House,5,,Marvin Sandnes,13
+Benton,18,U.S. House,5,,Kurt Schrader,506
+Benton,18,U.S. House,5,,Write-In Totals,0
+Benton,18,U.S. House,5,,Overvotes,0
+Benton,18,U.S. House,5,,Undervotes,54
+Benton,18,Governor,,,Aaron Auer,5
+Benton,18,Governor,,,Nick Chen,13
+Benton,18,Governor,,,Kate Brown,400
+Benton,18,Governor,,,Knute Buehler,848
+Benton,18,Governor,,,Patrick Starnes,36
+Benton,18,Governor,,,Chris Henry,2
+Benton,18,Governor,,,Write-In Totals,0
+Benton,18,Governor,,,Overvotes,0
+Benton,18,Governor,,,Undervotes,16
+Benton,18,State Senator,8,,Sara A Gelser,523
+Benton,18,State Senator,8,,Bryan Eggiman,32
+Benton,18,State Senator,8,,Erik S Parks,719
+Benton,18,State Senator,8,,Write-In Totals,1
+Benton,18,State Senator,8,,Overvotes,0
+Benton,18,State Senator,8,,Undervotes,45
+Benton,18,State Representative,15,,Jarred Taylor,393
+Benton,18,State Representative,15,,Shelly Boshart Davis,854
+Benton,18,State Representative,15,,Cynthia Hyatt,33
+Benton,18,State Representative,15,,Write-In Totals,3
+Benton,18,State Representative,15,,Overvotes,0
+Benton,18,State Representative,15,,Undervotes,37
+Benton,18,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,194
+Benton,18,"County Commissioner, Position 1",,,Erik Gradine,257
+Benton,18,"County Commissioner, Position 1",,,Timothy L Dehne,36
+Benton,18,"County Commissioner, Position 1",,,Pat Malone,422
+Benton,18,"County Commissioner, Position 1",,,Max Mania,112
+Benton,18,"County Commissioner, Position 1",,,Write-In Totals,20
+Benton,18,"County Commissioner, Position 1",,,Overvotes,0
+Benton,18,"County Commissioner, Position 1",,,Undervotes,279
+Benton,18,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,688
+Benton,18,"Judge of the Supreme Court, Position 5",,,Write-In Totals,18
+Benton,18,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,18,"Judge of the Supreme Court, Position 5",,,Undervotes,614
+Benton,18,"Judge of the Court of Appeals, Position 2",,,Bronson D James,664
+Benton,18,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,10
+Benton,18,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,18,"Judge of the Court of Appeals, Position 2",,,Undervotes,646
+Benton,18,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,663
+Benton,18,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,10
+Benton,18,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,18,"Judge of the Court of Appeals, Position 4",,,Undervotes,647
+Benton,18,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,662
+Benton,18,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,8
+Benton,18,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,18,"Judge of the Court of Appeals, Position 7",,,Undervotes,650
+Benton,18,Judge of the Oregon Tax Court,,,Robert Manicke,662
+Benton,18,Judge of the Oregon Tax Court,,,Write-In Totals,10
+Benton,18,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,18,Judge of the Oregon Tax Court,,,Undervotes,648
+Benton,18,Sheriff Benton County,,,Scott Jackson,732
+Benton,18,Sheriff Benton County,,,Write-In Totals,21
+Benton,18,Sheriff Benton County,,,Overvotes,0
+Benton,18,Sheriff Benton County,,,Undervotes,567
+Benton,18,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,695
+Benton,18,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,6
+Benton,18,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,18,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,619
+Benton,18,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,675
+Benton,18,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,5
+Benton,18,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,18,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,640
+Benton,18,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,633
+Benton,18,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,4
+Benton,18,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,18,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,683
+Benton,18,State Measure 102,,,Yes,548
+Benton,18,State Measure 102,,,No,739
+Benton,18,State Measure 102,,,Overvotes,0
+Benton,18,State Measure 102,,,Undervotes,33
+Benton,18,State Measure 103,,,Yes,630
+Benton,18,State Measure 103,,,No,670
+Benton,18,State Measure 103,,,Overvotes,1
+Benton,18,State Measure 103,,,Undervotes,19
+Benton,18,State Measure 104,,,Yes,639
+Benton,18,State Measure 104,,,No,642
+Benton,18,State Measure 104,,,Overvotes,0
+Benton,18,State Measure 104,,,Undervotes,39
+Benton,18,State Measure 105,,,Yes,680
+Benton,18,State Measure 105,,,No,621
+Benton,18,State Measure 105,,,Overvotes,0
+Benton,18,State Measure 105,,,Undervotes,19
+Benton,18,State Measure 106,,,Yes,633
+Benton,18,State Measure 106,,,No,668
+Benton,18,State Measure 106,,,Overvotes,0
+Benton,18,State Measure 106,,,Undervotes,19
+Benton,19,Registered Voters - Total,,,,1234
+Benton,19,Ballots Cast - Total,,,,995
+Benton,19,Ballots Cast - Blank,,,,0
+Benton,19,U.S. House,4,,Art Robinson,367
+Benton,19,U.S. House,4,,Richard R Jacobson,12
+Benton,19,U.S. House,4,,Mike Beilstein,18
+Benton,19,U.S. House,4,,Peter DeFazio,584
+Benton,19,U.S. House,4,,Write-In Totals,3
+Benton,19,U.S. House,4,,Overvotes,1
+Benton,19,U.S. House,4,,Undervotes,10
+Benton,19,Governor,,,Aaron Auer,10
+Benton,19,Governor,,,Nick Chen,11
+Benton,19,Governor,,,Kate Brown,506
+Benton,19,Governor,,,Knute Buehler,410
+Benton,19,Governor,,,Patrick Starnes,33
+Benton,19,Governor,,,Chris Henry,7
+Benton,19,Governor,,,Write-In Totals,1
+Benton,19,Governor,,,Overvotes,0
+Benton,19,Governor,,,Undervotes,16
+Benton,19,State Representative,23,,Danny Jaffer,575
+Benton,19,State Representative,23,,Mark Karnowski,18
+Benton,19,State Representative,23,,Mike Nearman,375
+Benton,19,State Representative,23,,Write-In Totals,1
+Benton,19,State Representative,23,,Overvotes,0
+Benton,19,State Representative,23,,Undervotes,25
+Benton,19,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,158
+Benton,19,"County Commissioner, Position 1",,,Erik Gradine,125
+Benton,19,"County Commissioner, Position 1",,,Timothy L Dehne,28
+Benton,19,"County Commissioner, Position 1",,,Pat Malone,489
+Benton,19,"County Commissioner, Position 1",,,Max Mania,78
+Benton,19,"County Commissioner, Position 1",,,Write-In Totals,12
+Benton,19,"County Commissioner, Position 1",,,Overvotes,0
+Benton,19,"County Commissioner, Position 1",,,Undervotes,104
+Benton,19,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,527
+Benton,19,"Judge of the Supreme Court, Position 5",,,Write-In Totals,10
+Benton,19,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,19,"Judge of the Supreme Court, Position 5",,,Undervotes,457
+Benton,19,"Judge of the Court of Appeals, Position 2",,,Bronson D James,492
+Benton,19,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,9
+Benton,19,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,19,"Judge of the Court of Appeals, Position 2",,,Undervotes,493
+Benton,19,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,517
+Benton,19,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,5
+Benton,19,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,19,"Judge of the Court of Appeals, Position 4",,,Undervotes,472
+Benton,19,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,505
+Benton,19,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,8
+Benton,19,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,19,"Judge of the Court of Appeals, Position 7",,,Undervotes,481
+Benton,19,Judge of the Oregon Tax Court,,,Robert Manicke,505
+Benton,19,Judge of the Oregon Tax Court,,,Write-In Totals,7
+Benton,19,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,19,Judge of the Oregon Tax Court,,,Undervotes,482
+Benton,19,Sheriff Benton County,,,Scott Jackson,555
+Benton,19,Sheriff Benton County,,,Write-In Totals,11
+Benton,19,Sheriff Benton County,,,Overvotes,0
+Benton,19,Sheriff Benton County,,,Undervotes,428
+Benton,19,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,522
+Benton,19,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,8
+Benton,19,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,19,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,464
+Benton,19,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,504
+Benton,19,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,6
+Benton,19,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,19,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,484
+Benton,19,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,500
+Benton,19,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,9
+Benton,19,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,19,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,485
+Benton,19,State Measure 102,,,Yes,513
+Benton,19,State Measure 102,,,No,461
+Benton,19,State Measure 102,,,Overvotes,1
+Benton,19,State Measure 102,,,Undervotes,19
+Benton,19,State Measure 103,,,Yes,351
+Benton,19,State Measure 103,,,No,620
+Benton,19,State Measure 103,,,Overvotes,0
+Benton,19,State Measure 103,,,Undervotes,23
+Benton,19,State Measure 104,,,Yes,343
+Benton,19,State Measure 104,,,No,620
+Benton,19,State Measure 104,,,Overvotes,0
+Benton,19,State Measure 104,,,Undervotes,31
+Benton,19,State Measure 105,,,Yes,325
+Benton,19,State Measure 105,,,No,651
+Benton,19,State Measure 105,,,Overvotes,0
+Benton,19,State Measure 105,,,Undervotes,18
+Benton,19,State Measure 106,,,Yes,317
+Benton,19,State Measure 106,,,No,657
+Benton,19,State Measure 106,,,Overvotes,1
+Benton,19,State Measure 106,,,Undervotes,19
+Benton,20,Registered Voters - Total,,,,1828
+Benton,20,Ballots Cast - Total,,,,1338
+Benton,20,Ballots Cast - Blank,,,,0
+Benton,20,U.S. House,4,,Art Robinson,700
+Benton,20,U.S. House,4,,Richard R Jacobson,16
+Benton,20,U.S. House,4,,Mike Beilstein,30
+Benton,20,U.S. House,4,,Peter DeFazio,569
+Benton,20,U.S. House,4,,Write-In Totals,1
+Benton,20,U.S. House,4,,Overvotes,0
+Benton,20,U.S. House,4,,Undervotes,22
+Benton,20,Governor,,,Aaron Auer,14
+Benton,20,Governor,,,Nick Chen,18
+Benton,20,Governor,,,Kate Brown,425
+Benton,20,Governor,,,Knute Buehler,810
+Benton,20,Governor,,,Patrick Starnes,44
+Benton,20,Governor,,,Chris Henry,8
+Benton,20,Governor,,,Write-In Totals,4
+Benton,20,Governor,,,Overvotes,0
+Benton,20,Governor,,,Undervotes,13
+Benton,20,State Representative,23,,Danny Jaffer,562
+Benton,20,State Representative,23,,Mark Karnowski,24
+Benton,20,State Representative,23,,Mike Nearman,698
+Benton,20,State Representative,23,,Write-In Totals,0
+Benton,20,State Representative,23,,Overvotes,0
+Benton,20,State Representative,23,,Undervotes,52
+Benton,20,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,122
+Benton,20,"County Commissioner, Position 1",,,Erik Gradine,270
+Benton,20,"County Commissioner, Position 1",,,Timothy L Dehne,65
+Benton,20,"County Commissioner, Position 1",,,Pat Malone,500
+Benton,20,"County Commissioner, Position 1",,,Max Mania,117
+Benton,20,"County Commissioner, Position 1",,,Write-In Totals,17
+Benton,20,"County Commissioner, Position 1",,,Overvotes,2
+Benton,20,"County Commissioner, Position 1",,,Undervotes,243
+Benton,20,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,691
+Benton,20,"Judge of the Supreme Court, Position 5",,,Write-In Totals,17
+Benton,20,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,20,"Judge of the Supreme Court, Position 5",,,Undervotes,628
+Benton,20,"Judge of the Court of Appeals, Position 2",,,Bronson D James,652
+Benton,20,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,17
+Benton,20,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,20,"Judge of the Court of Appeals, Position 2",,,Undervotes,667
+Benton,20,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,684
+Benton,20,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,15
+Benton,20,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,20,"Judge of the Court of Appeals, Position 4",,,Undervotes,637
+Benton,20,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,665
+Benton,20,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,17
+Benton,20,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,20,"Judge of the Court of Appeals, Position 7",,,Undervotes,654
+Benton,20,Judge of the Oregon Tax Court,,,Robert Manicke,665
+Benton,20,Judge of the Oregon Tax Court,,,Write-In Totals,17
+Benton,20,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,20,Judge of the Oregon Tax Court,,,Undervotes,654
+Benton,20,Sheriff Benton County,,,Scott Jackson,722
+Benton,20,Sheriff Benton County,,,Write-In Totals,20
+Benton,20,Sheriff Benton County,,,Overvotes,0
+Benton,20,Sheriff Benton County,,,Undervotes,594
+Benton,20,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,685
+Benton,20,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,14
+Benton,20,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,20,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,637
+Benton,20,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,658
+Benton,20,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,14
+Benton,20,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,20,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,664
+Benton,20,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,692
+Benton,20,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,17
+Benton,20,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,20,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,627
+Benton,20,State Measure 102,,,Yes,540
+Benton,20,State Measure 102,,,No,761
+Benton,20,State Measure 102,,,Overvotes,0
+Benton,20,State Measure 102,,,Undervotes,35
+Benton,20,State Measure 103,,,Yes,623
+Benton,20,State Measure 103,,,No,683
+Benton,20,State Measure 103,,,Overvotes,0
+Benton,20,State Measure 103,,,Undervotes,30
+Benton,20,State Measure 104,,,Yes,591
+Benton,20,State Measure 104,,,No,696
+Benton,20,State Measure 104,,,Overvotes,0
+Benton,20,State Measure 104,,,Undervotes,49
+Benton,20,State Measure 105,,,Yes,608
+Benton,20,State Measure 105,,,No,690
+Benton,20,State Measure 105,,,Overvotes,0
+Benton,20,State Measure 105,,,Undervotes,38
+Benton,20,State Measure 106,,,Yes,634
+Benton,20,State Measure 106,,,No,670
+Benton,20,State Measure 106,,,Overvotes,1
+Benton,20,State Measure 106,,,Undervotes,31
+Benton,21,Registered Voters - Total,,,,410
+Benton,21,Ballots Cast - Total,,,,326
+Benton,21,Ballots Cast - Blank,,,,0
+Benton,21,U.S. House,4,,Art Robinson,121
+Benton,21,U.S. House,4,,Richard R Jacobson,4
+Benton,21,U.S. House,4,,Mike Beilstein,9
+Benton,21,U.S. House,4,,Peter DeFazio,186
+Benton,21,U.S. House,4,,Write-In Totals,0
+Benton,21,U.S. House,4,,Overvotes,0
+Benton,21,U.S. House,4,,Undervotes,6
+Benton,21,Governor,,,Aaron Auer,3
+Benton,21,Governor,,,Nick Chen,9
+Benton,21,Governor,,,Kate Brown,141
+Benton,21,Governor,,,Knute Buehler,154
+Benton,21,Governor,,,Patrick Starnes,12
+Benton,21,Governor,,,Chris Henry,3
+Benton,21,Governor,,,Write-In Totals,0
+Benton,21,Governor,,,Overvotes,0
+Benton,21,Governor,,,Undervotes,4
+Benton,21,State Senator,8,,Sara A Gelser,177
+Benton,21,State Senator,8,,Bryan Eggiman,10
+Benton,21,State Senator,8,,Erik S Parks,125
+Benton,21,State Senator,8,,Write-In Totals,0
+Benton,21,State Senator,8,,Overvotes,0
+Benton,21,State Senator,8,,Undervotes,14
+Benton,21,State Representative,16,,Dan Rayfield,185
+Benton,21,State Representative,16,,Write-In Totals,8
+Benton,21,State Representative,16,,Overvotes,0
+Benton,21,State Representative,16,,Undervotes,133
+Benton,21,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,52
+Benton,21,"County Commissioner, Position 1",,,Erik Gradine,34
+Benton,21,"County Commissioner, Position 1",,,Timothy L Dehne,10
+Benton,21,"County Commissioner, Position 1",,,Pat Malone,152
+Benton,21,"County Commissioner, Position 1",,,Max Mania,23
+Benton,21,"County Commissioner, Position 1",,,Write-In Totals,0
+Benton,21,"County Commissioner, Position 1",,,Overvotes,0
+Benton,21,"County Commissioner, Position 1",,,Undervotes,55
+Benton,21,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,171
+Benton,21,"Judge of the Supreme Court, Position 5",,,Write-In Totals,2
+Benton,21,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,21,"Judge of the Supreme Court, Position 5",,,Undervotes,153
+Benton,21,"Judge of the Court of Appeals, Position 2",,,Bronson D James,165
+Benton,21,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,3
+Benton,21,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,21,"Judge of the Court of Appeals, Position 2",,,Undervotes,158
+Benton,21,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,165
+Benton,21,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,1
+Benton,21,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,21,"Judge of the Court of Appeals, Position 4",,,Undervotes,160
+Benton,21,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,164
+Benton,21,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,2
+Benton,21,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,21,"Judge of the Court of Appeals, Position 7",,,Undervotes,160
+Benton,21,Judge of the Oregon Tax Court,,,Robert Manicke,164
+Benton,21,Judge of the Oregon Tax Court,,,Write-In Totals,2
+Benton,21,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,21,Judge of the Oregon Tax Court,,,Undervotes,160
+Benton,21,Sheriff Benton County,,,Scott Jackson,184
+Benton,21,Sheriff Benton County,,,Write-In Totals,3
+Benton,21,Sheriff Benton County,,,Overvotes,0
+Benton,21,Sheriff Benton County,,,Undervotes,139
+Benton,21,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,174
+Benton,21,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,0
+Benton,21,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,21,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,152
+Benton,21,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,169
+Benton,21,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,0
+Benton,21,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,21,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,157
+Benton,21,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,161
+Benton,21,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,1
+Benton,21,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,21,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,164
+Benton,21,State Measure 102,,,Yes,164
+Benton,21,State Measure 102,,,No,152
+Benton,21,State Measure 102,,,Overvotes,0
+Benton,21,State Measure 102,,,Undervotes,10
+Benton,21,State Measure 103,,,Yes,116
+Benton,21,State Measure 103,,,No,208
+Benton,21,State Measure 103,,,Overvotes,0
+Benton,21,State Measure 103,,,Undervotes,2
+Benton,21,State Measure 104,,,Yes,120
+Benton,21,State Measure 104,,,No,194
+Benton,21,State Measure 104,,,Overvotes,0
+Benton,21,State Measure 104,,,Undervotes,12
+Benton,21,State Measure 105,,,Yes,121
+Benton,21,State Measure 105,,,No,198
+Benton,21,State Measure 105,,,Overvotes,0
+Benton,21,State Measure 105,,,Undervotes,7
+Benton,21,State Measure 106,,,Yes,121
+Benton,21,State Measure 106,,,No,203
+Benton,21,State Measure 106,,,Overvotes,0
+Benton,21,State Measure 106,,,Undervotes,2
+Benton,22,Registered Voters - Total,,,,508
+Benton,22,Ballots Cast - Total,,,,422
+Benton,22,Ballots Cast - Blank,,,,0
+Benton,22,U.S. House,5,,Mark Callahan,153
+Benton,22,U.S. House,5,,Dan Souza,4
+Benton,22,U.S. House,5,,Marvin Sandnes,10
+Benton,22,U.S. House,5,,Kurt Schrader,239
+Benton,22,U.S. House,5,,Write-In Totals,0
+Benton,22,U.S. House,5,,Overvotes,0
+Benton,22,U.S. House,5,,Undervotes,16
+Benton,22,Governor,,,Aaron Auer,5
+Benton,22,Governor,,,Nick Chen,6
+Benton,22,Governor,,,Kate Brown,209
+Benton,22,Governor,,,Knute Buehler,181
+Benton,22,Governor,,,Patrick Starnes,10
+Benton,22,Governor,,,Chris Henry,0
+Benton,22,Governor,,,Write-In Totals,0
+Benton,22,Governor,,,Overvotes,1
+Benton,22,Governor,,,Undervotes,7
+Benton,22,State Representative,23,,Danny Jaffer,226
+Benton,22,State Representative,23,,Mark Karnowski,6
+Benton,22,State Representative,23,,Mike Nearman,167
+Benton,22,State Representative,23,,Write-In Totals,1
+Benton,22,State Representative,23,,Overvotes,0
+Benton,22,State Representative,23,,Undervotes,19
+Benton,22,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,79
+Benton,22,"County Commissioner, Position 1",,,Erik Gradine,70
+Benton,22,"County Commissioner, Position 1",,,Timothy L Dehne,9
+Benton,22,"County Commissioner, Position 1",,,Pat Malone,167
+Benton,22,"County Commissioner, Position 1",,,Max Mania,32
+Benton,22,"County Commissioner, Position 1",,,Write-In Totals,1
+Benton,22,"County Commissioner, Position 1",,,Overvotes,0
+Benton,22,"County Commissioner, Position 1",,,Undervotes,61
+Benton,22,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,233
+Benton,22,"Judge of the Supreme Court, Position 5",,,Write-In Totals,5
+Benton,22,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,22,"Judge of the Supreme Court, Position 5",,,Undervotes,181
+Benton,22,"Judge of the Court of Appeals, Position 2",,,Bronson D James,210
+Benton,22,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,5
+Benton,22,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,22,"Judge of the Court of Appeals, Position 2",,,Undervotes,204
+Benton,22,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,224
+Benton,22,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,4
+Benton,22,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,22,"Judge of the Court of Appeals, Position 4",,,Undervotes,191
+Benton,22,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,220
+Benton,22,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,4
+Benton,22,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,22,"Judge of the Court of Appeals, Position 7",,,Undervotes,195
+Benton,22,Judge of the Oregon Tax Court,,,Robert Manicke,217
+Benton,22,Judge of the Oregon Tax Court,,,Write-In Totals,5
+Benton,22,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,22,Judge of the Oregon Tax Court,,,Undervotes,197
+Benton,22,Sheriff Benton County,,,Scott Jackson,243
+Benton,22,Sheriff Benton County,,,Write-In Totals,7
+Benton,22,Sheriff Benton County,,,Overvotes,0
+Benton,22,Sheriff Benton County,,,Undervotes,169
+Benton,22,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,225
+Benton,22,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,22,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,22,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,191
+Benton,22,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,213
+Benton,22,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,3
+Benton,22,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,22,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,203
+Benton,22,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,209
+Benton,22,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,4
+Benton,22,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,22,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,206
+Benton,22,State Measure 102,,,Yes,227
+Benton,22,State Measure 102,,,No,180
+Benton,22,State Measure 102,,,Overvotes,0
+Benton,22,State Measure 102,,,Undervotes,12
+Benton,22,State Measure 103,,,Yes,146
+Benton,22,State Measure 103,,,No,265
+Benton,22,State Measure 103,,,Overvotes,0
+Benton,22,State Measure 103,,,Undervotes,8
+Benton,22,State Measure 104,,,Yes,154
+Benton,22,State Measure 104,,,No,254
+Benton,22,State Measure 104,,,Overvotes,0
+Benton,22,State Measure 104,,,Undervotes,11
+Benton,22,State Measure 105,,,Yes,146
+Benton,22,State Measure 105,,,No,266
+Benton,22,State Measure 105,,,Overvotes,0
+Benton,22,State Measure 105,,,Undervotes,7
+Benton,22,State Measure 106,,,Yes,144
+Benton,22,State Measure 106,,,No,268
+Benton,22,State Measure 106,,,Overvotes,0
+Benton,22,State Measure 106,,,Undervotes,7
+Benton,23,Registered Voters - Total,,,,783
+Benton,23,Ballots Cast - Total,,,,567
+Benton,23,Ballots Cast - Blank,,,,0
+Benton,23,U.S. House,4,,Art Robinson,197
+Benton,23,U.S. House,4,,Richard R Jacobson,12
+Benton,23,U.S. House,4,,Mike Beilstein,13
+Benton,23,U.S. House,4,,Peter DeFazio,334
+Benton,23,U.S. House,4,,Write-In Totals,0
+Benton,23,U.S. House,4,,Overvotes,0
+Benton,23,U.S. House,4,,Undervotes,11
+Benton,23,Governor,,,Aaron Auer,5
+Benton,23,Governor,,,Nick Chen,13
+Benton,23,Governor,,,Kate Brown,277
+Benton,23,Governor,,,Knute Buehler,239
+Benton,23,Governor,,,Patrick Starnes,14
+Benton,23,Governor,,,Chris Henry,5
+Benton,23,Governor,,,Write-In Totals,1
+Benton,23,Governor,,,Overvotes,1
+Benton,23,Governor,,,Undervotes,10
+Benton,23,State Senator,8,,Sara A Gelser,341
+Benton,23,State Senator,8,,Bryan Eggiman,18
+Benton,23,State Senator,8,,Erik S Parks,191
+Benton,23,State Senator,8,,Write-In Totals,0
+Benton,23,State Senator,8,,Overvotes,0
+Benton,23,State Senator,8,,Undervotes,15
+Benton,23,State Representative,15,,Jarred Taylor,280
+Benton,23,State Representative,15,,Shelly Boshart Davis,227
+Benton,23,State Representative,15,,Cynthia Hyatt,38
+Benton,23,State Representative,15,,Write-In Totals,0
+Benton,23,State Representative,15,,Overvotes,0
+Benton,23,State Representative,15,,Undervotes,20
+Benton,23,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,88
+Benton,23,"County Commissioner, Position 1",,,Erik Gradine,68
+Benton,23,"County Commissioner, Position 1",,,Timothy L Dehne,29
+Benton,23,"County Commissioner, Position 1",,,Pat Malone,260
+Benton,23,"County Commissioner, Position 1",,,Max Mania,54
+Benton,23,"County Commissioner, Position 1",,,Write-In Totals,4
+Benton,23,"County Commissioner, Position 1",,,Overvotes,0
+Benton,23,"County Commissioner, Position 1",,,Undervotes,62
+Benton,23,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,349
+Benton,23,"Judge of the Supreme Court, Position 5",,,Write-In Totals,8
+Benton,23,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,23,"Judge of the Supreme Court, Position 5",,,Undervotes,208
+Benton,23,"Judge of the Court of Appeals, Position 2",,,Bronson D James,342
+Benton,23,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,7
+Benton,23,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,23,"Judge of the Court of Appeals, Position 2",,,Undervotes,216
+Benton,23,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,346
+Benton,23,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,7
+Benton,23,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,23,"Judge of the Court of Appeals, Position 4",,,Undervotes,212
+Benton,23,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,337
+Benton,23,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,7
+Benton,23,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,23,"Judge of the Court of Appeals, Position 7",,,Undervotes,221
+Benton,23,Judge of the Oregon Tax Court,,,Robert Manicke,334
+Benton,23,Judge of the Oregon Tax Court,,,Write-In Totals,7
+Benton,23,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,23,Judge of the Oregon Tax Court,,,Undervotes,224
+Benton,23,Sheriff Benton County,,,Scott Jackson,351
+Benton,23,Sheriff Benton County,,,Write-In Totals,13
+Benton,23,Sheriff Benton County,,,Overvotes,0
+Benton,23,Sheriff Benton County,,,Undervotes,201
+Benton,23,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,337
+Benton,23,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,7
+Benton,23,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,23,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,221
+Benton,23,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,336
+Benton,23,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,4
+Benton,23,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,23,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,225
+Benton,23,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,313
+Benton,23,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,5
+Benton,23,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,23,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,247
+Benton,23,State Measure 102,,,Yes,291
+Benton,23,State Measure 102,,,No,259
+Benton,23,State Measure 102,,,Overvotes,1
+Benton,23,State Measure 102,,,Undervotes,14
+Benton,23,State Measure 103,,,Yes,224
+Benton,23,State Measure 103,,,No,336
+Benton,23,State Measure 103,,,Overvotes,0
+Benton,23,State Measure 103,,,Undervotes,5
+Benton,23,State Measure 104,,,Yes,177
+Benton,23,State Measure 104,,,No,381
+Benton,23,State Measure 104,,,Overvotes,0
+Benton,23,State Measure 104,,,Undervotes,7
+Benton,23,State Measure 105,,,Yes,188
+Benton,23,State Measure 105,,,No,372
+Benton,23,State Measure 105,,,Overvotes,0
+Benton,23,State Measure 105,,,Undervotes,5
+Benton,23,State Measure 106,,,Yes,187
+Benton,23,State Measure 106,,,No,372
+Benton,23,State Measure 106,,,Overvotes,0
+Benton,23,State Measure 106,,,Undervotes,6
+Benton,24,Registered Voters - Total,,,,3618
+Benton,24,Ballots Cast - Total,,,,2944
+Benton,24,Ballots Cast - Blank,,,,0
+Benton,24,U.S. House,5,,Mark Callahan,1288
+Benton,24,U.S. House,5,,Dan Souza,43
+Benton,24,U.S. House,5,,Marvin Sandnes,27
+Benton,24,U.S. House,5,,Kurt Schrader,1499
+Benton,24,U.S. House,5,,Write-In Totals,1
+Benton,24,U.S. House,5,,Overvotes,1
+Benton,24,U.S. House,5,,Undervotes,85
+Benton,24,Governor,,,Aaron Auer,26
+Benton,24,Governor,,,Nick Chen,55
+Benton,24,Governor,,,Kate Brown,1220
+Benton,24,Governor,,,Knute Buehler,1486
+Benton,24,Governor,,,Patrick Starnes,87
+Benton,24,Governor,,,Chris Henry,19
+Benton,24,Governor,,,Write-In Totals,2
+Benton,24,Governor,,,Overvotes,0
+Benton,24,Governor,,,Undervotes,46
+Benton,24,State Senator,8,,Sara A Gelser,1513
+Benton,24,State Senator,8,,Bryan Eggiman,51
+Benton,24,State Senator,8,,Erik S Parks,1285
+Benton,24,State Senator,8,,Write-In Totals,1
+Benton,24,State Senator,8,,Overvotes,0
+Benton,24,State Senator,8,,Undervotes,91
+Benton,24,State Representative,15,,Jarred Taylor,1246
+Benton,24,State Representative,15,,Shelly Boshart Davis,1503
+Benton,24,State Representative,15,,Cynthia Hyatt,106
+Benton,24,State Representative,15,,Write-In Totals,2
+Benton,24,State Representative,15,,Overvotes,0
+Benton,24,State Representative,15,,Undervotes,84
+Benton,24,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,462
+Benton,24,"County Commissioner, Position 1",,,Erik Gradine,511
+Benton,24,"County Commissioner, Position 1",,,Timothy L Dehne,71
+Benton,24,"County Commissioner, Position 1",,,Pat Malone,1133
+Benton,24,"County Commissioner, Position 1",,,Max Mania,280
+Benton,24,"County Commissioner, Position 1",,,Write-In Totals,15
+Benton,24,"County Commissioner, Position 1",,,Overvotes,0
+Benton,24,"County Commissioner, Position 1",,,Undervotes,469
+Benton,24,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1748
+Benton,24,"Judge of the Supreme Court, Position 5",,,Write-In Totals,30
+Benton,24,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,24,"Judge of the Supreme Court, Position 5",,,Undervotes,1163
+Benton,24,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1683
+Benton,24,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,21
+Benton,24,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,24,"Judge of the Court of Appeals, Position 2",,,Undervotes,1237
+Benton,24,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1719
+Benton,24,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,19
+Benton,24,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,24,"Judge of the Court of Appeals, Position 4",,,Undervotes,1203
+Benton,24,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1715
+Benton,24,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,17
+Benton,24,"Judge of the Court of Appeals, Position 7",,,Overvotes,1
+Benton,24,"Judge of the Court of Appeals, Position 7",,,Undervotes,1208
+Benton,24,Judge of the Oregon Tax Court,,,Robert Manicke,1702
+Benton,24,Judge of the Oregon Tax Court,,,Write-In Totals,17
+Benton,24,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,24,Judge of the Oregon Tax Court,,,Undervotes,1222
+Benton,24,Sheriff Benton County,,,Scott Jackson,1813
+Benton,24,Sheriff Benton County,,,Write-In Totals,45
+Benton,24,Sheriff Benton County,,,Overvotes,0
+Benton,24,Sheriff Benton County,,,Undervotes,1083
+Benton,24,Mayor - City of Albany,,,Sharon Konopa,1773
+Benton,24,Mayor - City of Albany,,,Charley R Smith,754
+Benton,24,Mayor - City of Albany,,,Write-In Totals,25
+Benton,24,Mayor - City of Albany,,,Overvotes,0
+Benton,24,Mayor - City of Albany,,,Undervotes,389
+Benton,24,"Councilor, Ward 1-A City of Albany",,,Dick Olsen,1804
+Benton,24,"Councilor, Ward 1-A City of Albany",,,Write-In Totals,59
+Benton,24,"Councilor, Ward 1-A City of Albany",,,Overvotes,0
+Benton,24,"Councilor, Ward 1-A City of Albany",,,Undervotes,1078
+Benton,24,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1656
+Benton,24,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,21
+Benton,24,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,24,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,1264
+Benton,24,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1619
+Benton,24,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,21
+Benton,24,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,24,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,1301
+Benton,24,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1605
+Benton,24,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,21
+Benton,24,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,24,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,1315
+Benton,24,State Measure 102,,,Yes,1435
+Benton,24,State Measure 102,,,No,1417
+Benton,24,State Measure 102,,,Overvotes,1
+Benton,24,State Measure 102,,,Undervotes,88
+Benton,24,State Measure 103,,,Yes,1260
+Benton,24,State Measure 103,,,No,1628
+Benton,24,State Measure 103,,,Overvotes,2
+Benton,24,State Measure 103,,,Undervotes,51
+Benton,24,State Measure 104,,,Yes,1148
+Benton,24,State Measure 104,,,No,1713
+Benton,24,State Measure 104,,,Overvotes,0
+Benton,24,State Measure 104,,,Undervotes,80
+Benton,24,State Measure 105,,,Yes,1201
+Benton,24,State Measure 105,,,No,1695
+Benton,24,State Measure 105,,,Overvotes,0
+Benton,24,State Measure 105,,,Undervotes,45
+Benton,24,State Measure 106,,,Yes,1231
+Benton,24,State Measure 106,,,No,1671
+Benton,24,State Measure 106,,,Overvotes,1
+Benton,24,State Measure 106,,,Undervotes,38
+Benton,25,Registered Voters - Total,,,,2750
+Benton,25,Ballots Cast - Total,,,,2142
+Benton,25,Ballots Cast - Blank,,,,1
+Benton,25,U.S. House,5,,Mark Callahan,976
+Benton,25,U.S. House,5,,Dan Souza,51
+Benton,25,U.S. House,5,,Marvin Sandnes,19
+Benton,25,U.S. House,5,,Kurt Schrader,1006
+Benton,25,U.S. House,5,,Write-In Totals,3
+Benton,25,U.S. House,5,,Overvotes,0
+Benton,25,U.S. House,5,,Undervotes,87
+Benton,25,Governor,,,Aaron Auer,16
+Benton,25,Governor,,,Nick Chen,39
+Benton,25,Governor,,,Kate Brown,839
+Benton,25,Governor,,,Knute Buehler,1135
+Benton,25,Governor,,,Patrick Starnes,65
+Benton,25,Governor,,,Chris Henry,13
+Benton,25,Governor,,,Write-In Totals,4
+Benton,25,Governor,,,Overvotes,0
+Benton,25,Governor,,,Undervotes,28
+Benton,25,State Senator,8,,Sara A Gelser,1048
+Benton,25,State Senator,8,,Bryan Eggiman,49
+Benton,25,State Senator,8,,Erik S Parks,953
+Benton,25,State Senator,8,,Write-In Totals,3
+Benton,25,State Senator,8,,Overvotes,0
+Benton,25,State Senator,8,,Undervotes,86
+Benton,25,State Representative,15,,Jarred Taylor,835
+Benton,25,State Representative,15,,Shelly Boshart Davis,1134
+Benton,25,State Representative,15,,Cynthia Hyatt,79
+Benton,25,State Representative,15,,Write-In Totals,6
+Benton,25,State Representative,15,,Overvotes,0
+Benton,25,State Representative,15,,Undervotes,85
+Benton,25,"County Commissioner, Position 1",,,Sami Al-Abdrabbuh,319
+Benton,25,"County Commissioner, Position 1",,,Erik Gradine,341
+Benton,25,"County Commissioner, Position 1",,,Timothy L Dehne,39
+Benton,25,"County Commissioner, Position 1",,,Pat Malone,828
+Benton,25,"County Commissioner, Position 1",,,Max Mania,220
+Benton,25,"County Commissioner, Position 1",,,Write-In Totals,9
+Benton,25,"County Commissioner, Position 1",,,Overvotes,0
+Benton,25,"County Commissioner, Position 1",,,Undervotes,383
+Benton,25,"Judge of the Supreme Court, Position 5",,,Adrienne Nelson,1260
+Benton,25,"Judge of the Supreme Court, Position 5",,,Write-In Totals,15
+Benton,25,"Judge of the Supreme Court, Position 5",,,Overvotes,0
+Benton,25,"Judge of the Supreme Court, Position 5",,,Undervotes,864
+Benton,25,"Judge of the Court of Appeals, Position 2",,,Bronson D James,1214
+Benton,25,"Judge of the Court of Appeals, Position 2",,,Write-In Totals,10
+Benton,25,"Judge of the Court of Appeals, Position 2",,,Overvotes,0
+Benton,25,"Judge of the Court of Appeals, Position 2",,,Undervotes,915
+Benton,25,"Judge of the Court of Appeals, Position 4",,,Robyn Ridler Aoyagi,1239
+Benton,25,"Judge of the Court of Appeals, Position 4",,,Write-In Totals,10
+Benton,25,"Judge of the Court of Appeals, Position 4",,,Overvotes,0
+Benton,25,"Judge of the Court of Appeals, Position 4",,,Undervotes,890
+Benton,25,"Judge of the Court of Appeals, Position 7",,,Steven R Powers,1219
+Benton,25,"Judge of the Court of Appeals, Position 7",,,Write-In Totals,9
+Benton,25,"Judge of the Court of Appeals, Position 7",,,Overvotes,0
+Benton,25,"Judge of the Court of Appeals, Position 7",,,Undervotes,911
+Benton,25,Judge of the Oregon Tax Court,,,Robert Manicke,1217
+Benton,25,Judge of the Oregon Tax Court,,,Write-In Totals,7
+Benton,25,Judge of the Oregon Tax Court,,,Overvotes,0
+Benton,25,Judge of the Oregon Tax Court,,,Undervotes,915
+Benton,25,Sheriff Benton County,,,Scott Jackson,1311
+Benton,25,Sheriff Benton County,,,Write-In Totals,36
+Benton,25,Sheriff Benton County,,,Overvotes,0
+Benton,25,Sheriff Benton County,,,Undervotes,792
+Benton,25,Mayor - City of Albany,,,Sharon Konopa,1313
+Benton,25,Mayor - City of Albany,,,Charley R Smith,542
+Benton,25,Mayor - City of Albany,,,Write-In Totals,21
+Benton,25,Mayor - City of Albany,,,Overvotes,0
+Benton,25,Mayor - City of Albany,,,Undervotes,263
+Benton,25,"Councilor, Ward 1-A City of Albany",,,Dick Olsen,1308
+Benton,25,"Councilor, Ward 1-A City of Albany",,,Write-In Totals,33
+Benton,25,"Councilor, Ward 1-A City of Albany",,,Overvotes,0
+Benton,25,"Councilor, Ward 1-A City of Albany",,,Undervotes,798
+Benton,25,"Director, Zone 1 Benton Soil and Water Conservation District",,,Clifford A Hall,1196
+Benton,25,"Director, Zone 1 Benton Soil and Water Conservation District",,,Write-In Totals,8
+Benton,25,"Director, Zone 1 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,25,"Director, Zone 1 Benton Soil and Water Conservation District",,,Undervotes,935
+Benton,25,"Director, Zone 4 Benton Soil and Water Conservation District",,,Grahm Trask,1170
+Benton,25,"Director, Zone 4 Benton Soil and Water Conservation District",,,Write-In Totals,7
+Benton,25,"Director, Zone 4 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,25,"Director, Zone 4 Benton Soil and Water Conservation District",,,Undervotes,962
+Benton,25,"Director, Zone 5 Benton Soil and Water Conservation District",,,Larry A Lee,1160
+Benton,25,"Director, Zone 5 Benton Soil and Water Conservation District",,,Write-In Totals,8
+Benton,25,"Director, Zone 5 Benton Soil and Water Conservation District",,,Overvotes,0
+Benton,25,"Director, Zone 5 Benton Soil and Water Conservation District",,,Undervotes,971
+Benton,25,State Measure 102,,,Yes,1008
+Benton,25,State Measure 102,,,No,1068
+Benton,25,State Measure 102,,,Overvotes,0
+Benton,25,State Measure 102,,,Undervotes,63
+Benton,25,State Measure 103,,,Yes,903
+Benton,25,State Measure 103,,,No,1194
+Benton,25,State Measure 103,,,Overvotes,2
+Benton,25,State Measure 103,,,Undervotes,40
+Benton,25,State Measure 104,,,Yes,807
+Benton,25,State Measure 104,,,No,1260
+Benton,25,State Measure 104,,,Overvotes,1
+Benton,25,State Measure 104,,,Undervotes,71
+Benton,25,State Measure 105,,,Yes,870
+Benton,25,State Measure 105,,,No,1224
+Benton,25,State Measure 105,,,Overvotes,1
+Benton,25,State Measure 105,,,Undervotes,44
+Benton,25,State Measure 106,,,Yes,895
+Benton,25,State Measure 106,,,No,1208
+Benton,25,State Measure 106,,,Overvotes,0
+Benton,25,State Measure 106,,,Undervotes,36


### PR DESCRIPTION
As usual, Ghostscript came to the rescue (`gs -sDEVICE=txtwrite -o output.txt input.pdf`).

The code used to parse the resulting text file is a variation of the code I use to parse the results from Texas counties who publish results in a certain PDF format (Aransas, for example).
I'm also realizing that I never actually pushed the code in question to the data-tx repo. Whoops.

The parsing was much easier, mostly because there's only one type of vote (Another pro for balloting by mail only).