### PR TITLE
Remove extra column header

### DIFF
--- a/2008/20081104__or__general__precinct.csv
+++ b/2008/20081104__or__general__precinct.csv
@@ -1,4 +1,4 @@
-county,precinct,office,district,candidate,party,votes,vtd
+county,precinct,office,district,candidate,party,votes
 Coos,0001 LAKESIDE CITY & RURAL,Attorney General,,John R Kroger,DEM,707
 Coos,0002 RURAL NORTH BEND,Attorney General,,John R Kroger,DEM,1380
 Coos,0003 NORTH BEND CITY WEST,Attorney General,,John R Kroger,DEM,1565


### PR DESCRIPTION
The `vtd` column did not have any corresponding entries.