### PR TITLE
Narrow per-line bare excepts in the OR parsers

### DIFF
--- a/src/parsers/marion_parser.py
+++ b/src/parsers/marion_parser.py
@@ -127,7 +127,7 @@ def process_line(line, keys, w, party):
                 for cand in candidate_keys:
                     try:
                         w.writerow(['Marion', precinct, office, district, cand['party'], cand['name'], result_bits[cand['code']]])
-                    except:
+                    except (KeyError, IndexError, ValueError):
                         print result_bits
                         raise
                         #w.writerow(['Multnomah', precinct, 'Total', None, cand['party'], cand['name'], result_bits[cand['code']]])
@@ -157,5 +157,5 @@ with open('20000516__or__primary__marion__precinct2.csv', 'wb') as csvfile:
             keys = []
         try:
             process_line(line, keys, w, party=None)
-        except:
+        except (KeyError, IndexError, ValueError):
             raise

--- a/src/parsers/multnomah_parser.py
+++ b/src/parsers/multnomah_parser.py
@@ -142,7 +142,7 @@ def process_line(line, keys, w, party):
                 for cand in candidate_keys:
                     try:
                         w.writerow(['Multnomah', precinct, office, district, cand['party'], cand['name'], result_bits[cand['code']]])
-                    except:
+                    except (KeyError, IndexError, ValueError):
                         continue
                         #w.writerow(['Multnomah', precinct, 'Total', None, cand['party'], cand['name'], result_bits[cand['code']]])
 #        else:
@@ -173,5 +173,5 @@ with open('20100518__or__primary__multnomah__precinct.csv', 'wb') as csvfile:
             keys = []
         try:
             process_line(line, keys, w, party)
-        except:
+        except (KeyError, IndexError, ValueError):
             continue

--- a/src/parsers/union_parser.py
+++ b/src/parsers/union_parser.py
@@ -70,7 +70,7 @@ with open('20160517__or__primary__union__precinct.csv', 'wb') as csvfile:
             else:
                 try:
                     cand_and_party, votes, pct = cand_bits
-                except:
+                except (KeyError, IndexError, ValueError):
                     continue
             if "(" in cand_and_party:
                 candidate, party = [x.strip() for x in cand_and_party.split('(')]


### PR DESCRIPTION
flake8 E722. Each `except:` block in the Multnomah, Marion, and Union parsers wraps a per-row dict / index / cast and just continues on failure. Narrow to `(KeyError, IndexError, ValueError)` so we stop swallowing KeyboardInterrupt during a long parse.